### PR TITLE
Add new ref target for linux trusty

### DIFF
--- a/aosp_diff/linux_trusty/trusty/external/lk/0001-x64-64-enabling-patch-for-google-diff.patch
+++ b/aosp_diff/linux_trusty/trusty/external/lk/0001-x64-64-enabling-patch-for-google-diff.patch
@@ -1,0 +1,2630 @@
+From a641dd35bc4baf83d50749d15b24407aa6096423 Mon Sep 17 00:00:00 2001
+From: Zhong,Fangjian <fangjian.zhong@intel.com>
+Date: Mon, 23 Apr 2018 08:20:33 +0800
+Subject: [PATCH] x64-64 enabling patch for Google diff
+
+Change-Id: I2b4c0d513d24b6d913d0273a31ee5f2485d9a76b
+Signed-off-by: Zhong,Fangjian <fangjian.zhong@intel.com>
+---
+
+diff --git a/arch/x86/32/mmu.c b/arch/x86/32/mmu.c
+index 4ff7daa..253626f 100644
+--- a/arch/x86/32/mmu.c
++++ b/arch/x86/32/mmu.c
+@@ -1,6 +1,6 @@
+ /*
+  * Copyright (c) 2009 Corey Tabaka
+- * Copyright (c) 2015 Intel Corporation
++ * Copyright (c) 2015-2018 Intel Corporation
+  * Copyright (c) 2016 Travis Geiselbrecht
+  *
+  * Permission is hereby granted, free of charge, to any person obtaining
+@@ -623,9 +623,9 @@
+     x86_set_cr4(cr4);
+ 
+     /* Set NXE bit in MSR_EFER*/
+-    efer_msr = read_msr(x86_MSR_EFER);
+-    efer_msr |= x86_EFER_NXE;
+-    write_msr(x86_MSR_EFER, efer_msr);
++    efer_msr = read_msr(X86_MSR_EFER);
++    efer_msr |= X86_EFER_NXE;
++    write_msr(X86_MSR_EFER, efer_msr);
+ #endif
+ 
+     /* unmap the lower identity mapping */
+diff --git a/arch/x86/64/exceptions.S b/arch/x86/64/exceptions.S
+index a8aaf6d..d81c6e8 100644
+--- a/arch/x86/64/exceptions.S
++++ b/arch/x86/64/exceptions.S
+@@ -1,6 +1,6 @@
+ /*
+  * Copyright (c) 2009 Corey Tabaka
+- * Copyright (c) 2015 Intel Corporation
++ * Copyright (c) 2015-2018 Intel Corporation
+  * Copyright (c) 2016 Travis Geiselbrecht
+  *
+  * Permission is hereby granted, free of charge, to any person obtaining
+@@ -25,7 +25,7 @@
+ #include <asm.h>
+ #include <arch/x86/descriptor.h>
+ 
+-#define NUM_INT 0x31
++#define NUM_INT 0x100
+ #define NUM_EXC 0x14
+ 
+ .text
+@@ -38,11 +38,11 @@
+ .set isr_stub_start, .
+ 
+ .if i == 8 || (i >= 10 && i <= 14) || i == 17
+-        nop                                     /* error code pushed by exception */
+-        nop                                     /* 2 nops are the same length as push byte */
++.align 16
+         pushq $i                                /* interrupt number */
+         jmp interrupt_common
+ .else
++.align 16
+         pushq $0                                /* fill in error code in iframe */
+         pushq $i                                /* interrupt number */
+         jmp interrupt_common
+@@ -58,7 +58,12 @@
+ .fill 256
+ 
+ interrupt_common:
++    /* Check if from user space */
++    testb $3, 0x18(%rsp)
++    jz .Lskip_swapgs_in
++    swapgs
+ 
++.Lskip_swapgs_in:
+     /* save general purpose registers */
+     pushq %r15
+     pushq %r14
+@@ -97,6 +102,12 @@
+     popq %r14
+     popq %r15
+ 
++    /* check if back to user space */
++    testb $3, 0x18(%rsp)
++    jz .Lskip_swapgs_out
++    swapgs
++
++.Lskip_swapgs_out:
+     /* drop vector number and error code*/
+     addq $16, %rsp
+     iretq
+@@ -137,7 +148,7 @@
+ DATA(_idt)
+ 
+ .set i, 0
+-.rept NUM_INT-1
++.rept NUM_INT
+     .short 0        /* low 16 bits of ISR offset (_isr#i & 0FFFFh) */
+     .short CODE_64_SELECTOR   /* selector */
+     .byte  0
+diff --git a/arch/x86/64/kernel.ld b/arch/x86/64/kernel.ld
+index f06d1a3..27d280c 100644
+--- a/arch/x86/64/kernel.ld
++++ b/arch/x86/64/kernel.ld
+@@ -1,7 +1,7 @@
+ /*
+  * Copyright (c) 2009 Corey Tabaka
+  * Copyright (c) 2013 Travis Geiselbrecht
+- * Copyright (c) 2015 Intel Corporation
++ * Copyright (c) 2015-2018 Intel Corporation
+  *
+  * Permission is hereby granted, free of charge, to any person obtaining
+  * a copy of this software and associated documentation files
+@@ -23,7 +23,7 @@
+  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+  */
+ 
+-ENTRY(_start)
++ENTRY(_start_pa)
+ SECTIONS
+ {
+     . = %KERNEL_BASE% + %KERNEL_LOAD_OFFSET%;
+diff --git a/arch/x86/64/mmu.c b/arch/x86/64/mmu.c
+index 60a10c8..006abf3 100644
+--- a/arch/x86/64/mmu.c
++++ b/arch/x86/64/mmu.c
+@@ -1,6 +1,6 @@
+ /*
+  * Copyright (c) 2009 Corey Tabaka
+- * Copyright (c) 2015 Intel Corporation
++ * Copyright (c) 2015-2018 Intel Corporation
+  * Copyright (c) 2016 Travis Geiselbrecht
+  *
+  * Permission is hereby granted, free of charge, to any person obtaining
+@@ -43,16 +43,20 @@
+ uint8_t g_vaddr_width = 0;
+ uint8_t g_paddr_width = 0;
+ 
++paddr_t x86_kernel_page_table = 0;
++
+ /* top level kernel page tables, initialized in start.S */
+ map_addr_t pml4[NO_OF_PT_ENTRIES] __ALIGNED(PAGE_SIZE);
+-map_addr_t pdp[NO_OF_PT_ENTRIES] __ALIGNED(PAGE_SIZE); /* temporary */
+-map_addr_t pte[NO_OF_PT_ENTRIES] __ALIGNED(PAGE_SIZE);
++/* temporary low 512GB mapping, removed at x86_mmu_early_init */
++map_addr_t pdp[NO_OF_PT_ENTRIES] __ALIGNED(PAGE_SIZE);
++/* Enlarge to map 4GB, for MMIO mapping */
++map_addr_t pte[NO_OF_PT_ENTRIES * 4] __ALIGNED(PAGE_SIZE);
+ 
+ /* top level pdp needed to map the -512GB..0 space */
+ map_addr_t pdp_high[NO_OF_PT_ENTRIES] __ALIGNED(PAGE_SIZE);
+ 
+ /* a big pile of page tables needed to map 64GB of memory into kernel space using 2MB pages */
+-map_addr_t linear_map_pdp[(64ULL*GB) / (2*MB)];
++map_addr_t linear_map_pdp[(64ULL*GB) / (2*MB)] __ALIGNED(PAGE_SIZE);
+ 
+ /**
+  * @brief  check if the virtual address is aligned and canonical
+@@ -146,7 +150,11 @@
+ {
+     uint64_t pfn;
+ 
++    /* Clear low 12 bits */
+     pfn = (pte & X86_PG_FRAME);
++
++    /* Clear high 12 bits */
++    pfn &= X86_PHY_ADDR_MASK;
+     return pfn;
+ }
+ 
+@@ -174,8 +182,14 @@
+     if (flags & ARCH_MMU_FLAG_PERM_USER)
+         arch_flags |= X86_MMU_PG_U;
+ 
+-    if (flags & ARCH_MMU_FLAG_UNCACHED)
+-        arch_flags |= X86_MMU_CACHE_DISABLE;
++    /*
++     * for cached, PAT:PCD:PWT is 000 (default)
++     * for uncached, PAT:PCD:PWT is 011
++     */
++    if (flags & ARCH_MMU_FLAG_UNCACHED) {
++        arch_flags |= X86_MMU_PG_PCD;
++        arch_flags |= X86_MMU_PG_PWT;
++    }
+ 
+     if (flags & ARCH_MMU_FLAG_PERM_NO_EXECUTE)
+         arch_flags |= X86_MMU_PG_NX;
+@@ -196,8 +210,13 @@
+     if (flags & X86_MMU_PG_U)
+         mmu_flags |= ARCH_MMU_FLAG_PERM_USER;
+ 
+-    if (flags & X86_MMU_CACHE_DISABLE)
++    /* Default memory type is CACHED/WB */
++    if ((flags & X86_MMU_PG_PCD) &&
++        (flags & X86_MMU_PG_PWT) &&
++        !(flags & X86_MMU_PG_PTE_PAT))
+         mmu_flags |= ARCH_MMU_FLAG_UNCACHED;
++    else
++        mmu_flags |= ARCH_MMU_FLAG_CACHED;
+ 
+     if (flags & X86_MMU_PG_NX)
+         mmu_flags |= ARCH_MMU_FLAG_PERM_NO_EXECUTE;
+@@ -397,7 +416,7 @@
+                              vaddr_t vaddr, arch_flags_t mmu_flags)
+ {
+     uint32_t pd_new = 0, pdp_new = 0;
+-    uint64_t pml4e, pdpe, pde;
++    uint64_t pml4e, pdpe, pde = 0;
+     map_addr_t *m = NULL;
+     status_t ret = NO_ERROR;
+ 
+@@ -443,14 +462,31 @@
+     if (!pd_new)
+         pde = get_pd_entry_from_pd_table(vaddr, pdpe);
+ 
+-    if (pd_new || (pde & X86_MMU_PG_P) == 0) {
++    if (pd_new || (pde & X86_MMU_PG_P) == 0 || (pde & X86_MMU_PG_PS) != 0) {
+         /* Creating a new pt */
++        bool need_expand = !!(pde & X86_MMU_PG_PS);
+         m  = _map_alloc_page();
+         if (m == NULL) {
+             ret = ERR_NO_MEMORY;
+             if (pd_new)
+                 goto clean_pd;
+             goto clean;
++        }
++
++        /* If preview table is 2M page leaf, expand to 4K page leaves */
++        if (need_expand) {
++            uint64_t pd_paddr = X86_VIRT_TO_PHYS(pde);
++            arch_flags_t flag = get_x86_arch_flags(pde);
++            uint64_t *pt_table = (uint64_t *)((uint64_t)m & X86_PG_FRAME);
++            uint32_t index;
++
++            for (index = 0; index < 512; index++) {
++                pt_table[index] = (uint64_t)pd_paddr;
++                pt_table[index] |= flag | X86_MMU_PG_P;
++                if (!(flag & X86_MMU_PG_U))
++                    pt_table[index] |= X86_MMU_PG_G;
++                pd_paddr += 4096;
++            }
+         }
+ 
+         update_pd_entry(vaddr, pdpe, X86_VIRT_TO_PHYS(m), get_x86_arch_flags(mmu_flags));
+@@ -481,7 +517,7 @@
+ static void x86_mmu_unmap_entry(vaddr_t vaddr, int level, vaddr_t table_entry)
+ {
+     uint32_t offset = 0, next_level_offset = 0;
+-    vaddr_t *table, *next_table_addr, value;
++    vaddr_t *table, *next_table_addr;
+ 
+     LTRACEF("vaddr 0x%lx level %d table_entry 0x%lx\n", vaddr, level, table_entry);
+ 
+@@ -545,12 +581,10 @@
+         }
+         pmm_free_page(paddr_to_vm_page(X86_VIRT_TO_PHYS(next_table_addr)));
+     }
+-    /* All present bits for all entries in next level table for this address are 0 */
++    /* zero PTE to avoid L1TF issue */
+     if ((X86_PHYS_TO_VIRT(table[offset]) & X86_MMU_PG_P) != 0) {
+         arch_disable_ints();
+-        value = table[offset];
+-        value = value & X86_PTE_NOT_PRESENT;
+-        table[offset] = value;
++        table[offset] = 0;
+         arch_enable_ints();
+     }
+ }
+@@ -569,6 +603,11 @@
+     next_aligned_v_addr = vaddr;
+     while (count > 0) {
+         x86_mmu_unmap_entry(next_aligned_v_addr, X86_PAGING_LEVELS, pml4);
++        /*
++         * Flush page mapping in TLB when unmapping pages,
++         * need to invalid page to avoid data loss.
++         */
++        __asm__ __volatile__ ("invlpg (%0)": : "r" (next_aligned_v_addr) : "memory");
+         next_aligned_v_addr += PAGE_SIZE;
+         count--;
+     }
+@@ -589,8 +628,8 @@
+     if (count == 0)
+         return NO_ERROR;
+ 
+-    DEBUG_ASSERT(x86_get_cr3());
+-    current_cr3_val = (addr_t)x86_get_cr3();
++    current_cr3_val = aspace->page_table;
++    DEBUG_ASSERT(current_cr3_val);
+ 
+     return (x86_mmu_unmap(X86_PHYS_TO_VIRT(current_cr3_val), vaddr, count));
+ }
+@@ -648,17 +687,15 @@
+ 
+     DEBUG_ASSERT(aspace);
+ 
+-    if (!paddr)
+-        return ERR_INVALID_ARGS;
+-
+-    DEBUG_ASSERT(x86_get_cr3());
+-    current_cr3_val = (addr_t)x86_get_cr3();
++    current_cr3_val = aspace->page_table;
++    DEBUG_ASSERT(current_cr3_val);
+ 
+     stat = x86_mmu_get_mapping(X86_PHYS_TO_VIRT(current_cr3_val), vaddr, &ret_level, &ret_flags, &last_valid_entry);
+     if (stat)
+         return stat;
+ 
+-    *paddr = (paddr_t)(last_valid_entry);
++    if (paddr)
++        *paddr = (paddr_t)(last_valid_entry);
+     LTRACEF("paddr 0x%llx\n", last_valid_entry);
+ 
+     /* converting x86 arch specific flags to arch mmu flags */
+@@ -686,8 +723,8 @@
+     if (count == 0)
+         return NO_ERROR;
+ 
+-    DEBUG_ASSERT(x86_get_cr3());
+-    current_cr3_val = (addr_t)x86_get_cr3();
++    current_cr3_val = aspace->page_table;
++    DEBUG_ASSERT(current_cr3_val);
+ 
+     range.start_vaddr = vaddr;
+     range.start_paddr = paddr;
+@@ -714,9 +751,9 @@
+     x86_set_cr4(cr4);
+ 
+     /* Set NXE bit in MSR_EFER*/
+-    efer_msr = read_msr(x86_MSR_EFER);
+-    efer_msr |= x86_EFER_NXE;
+-    write_msr(x86_MSR_EFER, efer_msr);
++    efer_msr = read_msr(X86_MSR_EFER);
++    efer_msr |= X86_EFER_NXE;
++    write_msr(X86_MSR_EFER, efer_msr);
+ 
+     /* getting the address width from CPUID instr */
+     /* Bits 07-00: Physical Address width info */
+@@ -730,6 +767,8 @@
+     /* unmap the lower identity mapping */
+     pml4[0] = 0;
+ 
++    x86_kernel_page_table = x86_get_cr3();
++
+     /* tlb flush */
+     x86_set_cr3(x86_get_cr3());
+ }
+@@ -738,16 +777,29 @@
+ {
+ }
+ 
+-/*
+- * x86-64 does not support multiple address spaces at the moment, so fail if these apis
+- * are used for it.
+- */
++static paddr_t x86_create_page_table(void)
++{
++    addr_t *new_table = NULL;
++
++    new_table = (addr_t *)_map_alloc_page();
++    ASSERT(new_table);
++    new_table[511] = pml4[511];
++
++    return (paddr_t)X86_VIRT_TO_PHYS(new_table);
++}
++
+ status_t arch_mmu_init_aspace(arch_aspace_t *aspace, vaddr_t base, size_t size, uint flags)
+ {
+     DEBUG_ASSERT(aspace);
+ 
+-    if ((flags & ARCH_ASPACE_FLAG_KERNEL) == 0) {
+-        return ERR_NOT_SUPPORTED;
++    aspace->size = size;
++    aspace->base = base;
++
++    if ((flags & ARCH_ASPACE_FLAG_KERNEL)) {
++        aspace->page_table = x86_kernel_page_table;
++    } else {
++        if (0 == aspace->page_table)
++            aspace->page_table = x86_create_page_table();
+     }
+ 
+     return NO_ERROR;
+@@ -755,13 +807,20 @@
+ 
+ status_t arch_mmu_destroy_aspace(arch_aspace_t *aspace)
+ {
++    DEBUG_ASSERT(aspace);
++
++    aspace->size = 0;
++    aspace->base = 0;
++    aspace->page_table = 0;
++
+     return NO_ERROR;
+ }
+ 
+ void arch_mmu_context_switch(arch_aspace_t *aspace)
+ {
+-    if (aspace != NULL) {
+-        PANIC_UNIMPLEMENTED;
+-    }
++    if (NULL == aspace || 0 == aspace->page_table)
++        return;
++
++    x86_set_cr3(aspace->page_table);
+ }
+ 
+diff --git a/arch/x86/64/ops.S b/arch/x86/64/ops.S
+index 10b55bd..fd016f3 100644
+--- a/arch/x86/64/ops.S
++++ b/arch/x86/64/ops.S
+@@ -37,12 +37,12 @@
+ 
+ /* int _atomic_and(int *ptr, int val); */
+ FUNCTION(_atomic_and)
+-    movq (%rdi), %rax
++    mov (%rdi), %eax
+ 0:
+-    movq %rax, %rcx
+-    andq %rsi, %rcx
++    mov %eax, %ecx
++    and %esi, %ecx
+     lock
+-    cmpxchgq %rcx, (%rdi)
++    cmpxchg %ecx, (%rdi)
+     jnz 1f                  /* static prediction: branch forward not taken */
+     ret
+ 1:
+@@ -52,12 +52,12 @@
+ /* int _atomic_or(int *ptr, int val); */
+ FUNCTION(_atomic_or)
+ 
+-    movq (%rdi), %rax
++    mov (%rdi), %eax
+ 0:
+-    movq %rax, %rcx
+-    orq %rsi, %rcx
++    mov %eax, %ecx
++    or  %esi, %ecx
+     lock
+-    cmpxchgq %rcx, (%rdi)
++    cmpxchg %ecx, (%rdi)
+     jnz 1f                  /* static prediction: branch forward not taken */
+     ret
+ 1:
+diff --git a/arch/x86/64/start.S b/arch/x86/64/start.S
+index edf4e11..f9a5d33 100644
+--- a/arch/x86/64/start.S
++++ b/arch/x86/64/start.S
+@@ -39,8 +39,11 @@
+ /* The magic number passed by a Multiboot-compliant boot loader. */
+ #define MULTIBOOT_BOOTLOADER_MAGIC 0x2BADB002
+ 
+-#define MSR_EFER 0xc0000080
+-#define EFER_LME 0x00000100
++#define MSR_EFER    0xc0000080
++#define EFER_LME    0x00000100
++#define MSR_GS_BASE 0xc0000101
++#define PAT_MSR     0x277
++#define CACHE_MODE  0x70106
+ 
+ #define PHYS_LOAD_ADDRESS (MEMBASE + KERNEL_LOAD_OFFSET)
+ #define PHYS_ADDR_DELTA (KERNEL_BASE + KERNEL_LOAD_OFFSET - PHYS_LOAD_ADDRESS)
+@@ -134,6 +137,12 @@
+     orl $EFER_LME,%eax
+     wrmsr
+ 
++    /* setting the PAT MSRs */
++    movl $PAT_MSR, %ecx
++    movl $CACHE_MODE, %eax
++    movl $CACHE_MODE, %edx
++    wrmsr
++
+     /* Setting the First PML4E with a PDP table reference*/
+     movl $PHYS(pdp), %eax
+     orl  $X86_KERNEL_PD_FLAGS, %eax
+@@ -224,6 +233,14 @@
+     /* reload the gdtr */
+     lgdt _gdtr
+ 
++    /* set up gs base */
++    leaq global_states(%rip), %rax
++
++    movq %rax, %rdx
++    shr  $32, %rdx
++    movq $MSR_GS_BASE, %rcx
++    wrmsr
++
+     /* set up the idt */
+     call setup_idt
+ 
+diff --git a/arch/x86/64/usercopy.c b/arch/x86/64/usercopy.c
+new file mode 100644
+index 0000000..33fd918
+--- /dev/null
++++ b/arch/x86/64/usercopy.c
+@@ -0,0 +1,111 @@
++/*
++ * Copyright (c) 2018 Intel Corporation
++ *
++ * Permission is hereby granted, free of charge, to any person obtaining
++ * a copy of this software and associated documentation files
++ * (the "Software"), to deal in the Software without restriction,
++ * including without limitation the rights to use, copy, modify, merge,
++ * publish, distribute, sublicense, and/or sell copies of the Software,
++ * and to permit persons to whom the Software is furnished to do so,
++ * subject to the following conditions:
++ *
++ * The above copyright notice and this permission notice shall be
++ * included in all copies or substantial portions of the Software.
++ *
++ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
++ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
++ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
++ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
++ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
++ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
++ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
++ */
++#include <arch/usercopy.h>
++#include <string.h>
++#include <kernel/vm.h>
++#include <err.h>
++
++static vmm_region_t *get_region(user_addr_t vaddr)
++{
++    vmm_aspace_t *aspace = vaddr_to_aspace((void *)(uint64_t)vaddr);
++    vmm_region_t *region = NULL;
++
++    if (NULL == aspace) {
++        return NULL;
++    }
++
++    list_for_every_entry(&aspace->region_list, region, vmm_region_t, node) {
++        if ((region->base <= vaddr) &&
++                (vaddr < (region->base + region->size))) {
++            return region;
++        }
++    }
++
++    return NULL;
++}
++
++status_t arch_copy_from_user(void *kdest, user_addr_t usrc, size_t len)
++{
++    vmm_region_t *region = get_region(usrc);
++
++    if (0 == len)
++        return NO_ERROR;
++
++    if (NULL == kdest || 0 == usrc || NULL == region)
++        return ERR_FAULT;
++
++    if (usrc + len > region->size + region->base)
++        return ERR_FAULT;
++
++    __asm__ volatile("stac");
++    memcpy(kdest, (void *)(uint64_t)usrc, len);
++    __asm__ volatile("clac");
++
++    return NO_ERROR;
++}
++
++status_t arch_copy_to_user(user_addr_t udest, const void *ksrc, size_t len)
++{
++    vmm_region_t *region = get_region(udest);
++
++    if (0 == len)
++        return NO_ERROR;
++
++    if (NULL == ksrc || 0 == udest || NULL == region)
++        return ERR_FAULT;
++
++    if (udest + len > region->size + region->base)
++        return ERR_FAULT;
++
++    __asm__ volatile("stac");
++    memcpy((void *)(uint64_t)udest, ksrc, len);
++    __asm__ volatile("clac");
++
++    return NO_ERROR;
++}
++
++
++ssize_t arch_strlcpy_from_user(char *kdst, user_addr_t usrc, size_t len)
++{
++    size_t max_len = 0;
++    size_t act_len = len;
++    char  *ksrc = (char *)(uint64_t)usrc;
++    vmm_region_t *region = get_region(usrc);
++
++    if (NULL == region || 0 == len)
++        return 0;
++
++    max_len = region->size - (usrc - region->base);
++
++    if (len > max_len)
++        return (size_t)ERR_INVALID_ARGS;
++
++    __asm__ volatile("stac");
++    while (act_len-- && (*kdst++ = *ksrc++) != '\0')
++        ;
++    __asm__ volatile("clac");
++
++    act_len = len - act_len;
++
++    return act_len;
++}
+diff --git a/arch/x86/arch.c b/arch/x86/arch.c
+index 721c57e..cc81b93 100644
+--- a/arch/x86/arch.c
++++ b/arch/x86/arch.c
+@@ -1,6 +1,6 @@
+ /*
+  * Copyright (c) 2009 Corey Tabaka
+- * Copyright (c) 2015 Intel Corporation
++ * Copyright (c) 2015-2018 Intel Corporation
+  *
+  * Permission is hereby granted, free of charge, to any person obtaining
+  * a copy of this software and associated documentation files
+@@ -27,42 +27,108 @@
+ #include <arch/ops.h>
+ #include <arch/x86.h>
+ #include <arch/x86/mmu.h>
++#include <arch/x86/mp.h>
+ #include <arch/x86/descriptor.h>
+ #include <arch/fpu.h>
+ #include <arch/mmu.h>
+ #include <platform.h>
+ #include <sys/types.h>
+ #include <string.h>
++#include <assert.h>
+ 
+ /* early stack */
+-uint8_t _kstack[PAGE_SIZE] __ALIGNED(8);
++uint8_t _kstack[PAGE_SIZE * SMP_MAX_CPUS] __ALIGNED(8);
+ 
+ /* save a pointer to the multiboot information coming in from whoever called us */
+ /* make sure it lives in .data to avoid it being wiped out by bss clearing */
+ __SECTION(".data") void *_multiboot_info;
+ 
+ /* main tss */
+-static tss_t system_tss;
++static tss_t system_tss[SMP_MAX_CPUS];
++x86_global_states_t global_states[SMP_MAX_CPUS];
++volatile int cpu_waken_up = 0;
++extern uint64_t __tss_end;
++extern void x86_syscall(void);
+ 
++static void init_global_state(x86_global_states_t *states, uint cpu)
++{
++    states->cur_thread    = NULL;
++    states->syscall_stack = 0;
++
++    write_msr(X86_MSR_GS_BASE, (uint64_t)states);
++}
++
++void *get_tss_base(void)
++{
++    volatile uint cpu = arch_curr_cpu_num();
++    ASSERT(cpu < SMP_MAX_CPUS);
++
++    if (cpu < SMP_MAX_CPUS)
++        return &system_tss[cpu];
++    else
++        return NULL;
++}
++
++static void arch_set_tss_segment_percpu(void)
++{
++    uint64_t addr;
++    /* Get system tss segment */
++    tss_t *tss_base = get_tss_base();
++    uint cpu_id = arch_curr_cpu_num();
++
++    ASSERT(tss_base);
++    ASSERT(cpu_id < SMP_MAX_CPUS);
++
++    addr = (uint64_t)&__tss_end - (uint64_t)(cpu_id * PAGE_SIZE);
++
++    tss_base->rsp0 = addr;
++    x86_set_syscall_stack(addr);
++}
++
++static void arch_setup_syscall_percpu(void)
++{
++    /* msr_id,low,hi */
++    write_msr(SYSENTER_CS_MSR, CODE_64_SELECTOR);
++    write_msr(SYSENTER_ESP_MSR, x86_get_syscall_stack());
++    write_msr(SYSENTER_EIP_MSR, (uint64_t)(x86_syscall));
++}
+ void arch_early_init(void)
+ {
++    seg_sel_t sel = 0;
++    uint cpu_id = 1;
++
++    __asm__ __volatile__ (
++            "lock xaddq %%rax, (%%rdx)"
++            : "=a" (cpu_id)
++            : "a" (cpu_id), "d"(&cpu_waken_up));
++
++    /*
++     * At this point, BSP has set up current thread in global state,
++     * init global states of AP(s) only.
++     */
++    if (0 != cpu_id)
++        init_global_state(&global_states[cpu_id], cpu_id);
++
++    if (check_fsgsbase_avail())
++        x86_set_cr4(x86_get_cr4() | X86_CR4_FSGSBASE);
++    sel = (seg_sel_t)(cpu_id << 4);
++    sel += TSS_SELECTOR;
++
+     /* enable caches here for now */
+     clear_in_cr0(X86_CR0_NW | X86_CR0_CD);
+ 
+-    memset(&system_tss, 0, sizeof(system_tss));
++    memset(&system_tss[cpu_id], 0, sizeof(tss_t));
+ 
+-#if ARCH_X86_32
+-    system_tss.esp0 = 0;
+-    system_tss.ss0 = DATA_SELECTOR;
+-    system_tss.ss1 = 0;
+-    system_tss.ss2 = 0;
+-    system_tss.eflags = 0x00003002;
+-    system_tss.bitmap = offsetof(tss_32_t, tss_bitmap);
+-    system_tss.trace = 1; // trap on hardware task switch
+-#endif
+-
+-    set_global_desc(TSS_SELECTOR, &system_tss, sizeof(system_tss), 1, 0, 0, SEG_TYPE_TSS, 0, 0);
+-    x86_ltr(TSS_SELECTOR);
++    set_global_desc(sel,
++            &system_tss[cpu_id],
++            sizeof(tss_t),
++            1,
++            0,
++            0,
++            SEG_TYPE_TSS,
++            0,
++            0);
++    x86_ltr(sel);
+ 
+     x86_mmu_early_init();
+ }
+@@ -70,6 +136,9 @@
+ void arch_init(void)
+ {
+     x86_mmu_init();
++
++    arch_set_tss_segment_percpu();
++    arch_setup_syscall_percpu();
+ 
+ #ifdef X86_WITH_FPU
+     fpu_init();
+@@ -83,37 +152,42 @@
+ 
+ void arch_enter_uspace(vaddr_t entry_point, vaddr_t user_stack_top, uint32_t flags, ulong arg0)
+ {
+-    PANIC_UNIMPLEMENTED;
+-#if 0
+-    DEBUG_ASSERT(IS_ALIGNED(user_stack_top, 16));
++    register uint64_t sp_usr  = user_stack_top;
++    register uint64_t entry = entry_point;
++    register uint64_t code_seg = USER_CODE_64_SELECTOR | USER_RPL;
++    register uint64_t data_seg = USER_DATA_64_SELECTOR | USER_RPL;
++    register uint64_t usr_flags = USER_EFLAGS;
+ 
+-    thread_t *ct = get_current_thread();
+-
+-    vaddr_t kernel_stack_top = (uintptr_t)ct->stack + ct->stack_size;
+-    kernel_stack_top = ROUNDDOWN(kernel_stack_top, 16);
+-
+-    /* set up a default spsr to get into 64bit user space:
+-     * zeroed NZCV
+-     * no SS, no IL, no D
+-     * all interrupts enabled
+-     * mode 0: EL0t
+-     */
+-    uint32_t spsr = 0;
+-
+-    arch_disable_ints();
+-
+-    asm volatile(
+-        "mov    sp, %[kstack];"
+-        "msr    sp_el0, %[ustack];"
+-        "msr    elr_el1, %[entry];"
+-        "msr    spsr_el1, %[spsr];"
+-        "eret;"
+-        :
+-        : [ustack]"r"(user_stack_top),
+-        [kstack]"r"(kernel_stack_top),
+-        [entry]"r"(entry_point),
+-        [spsr]"r"(spsr)
+-        : "memory");
++    __asm__ __volatile__ (
++            "pushq %0   \n\t"
++            "pushq %1   \n\t"
++            "pushq %2   \n\t"
++            "pushq %3   \n\t"
++            "pushq %4   \n\t"
++            "pushq %0   \n\t"
++            "popq %%rax \n\t"
++            "swapgs \n\t"
++            "movw %%ax, %%ds    \n\t"
++            "movw %%ax, %%es    \n\t"
++            "movw %%ax, %%fs    \n\t"
++            "movw %%ax, %%gs    \n\t"
++            "iretq"
++            :
++            :"r"(data_seg),"r"(sp_usr),"r"(usr_flags),"r"(code_seg),"r"(entry));
+     __UNREACHABLE;
+-#endif
++}
++
++void arch_syscall_stack_switch(vaddr_t new_thread_syscall)
++{
++    tss_t *tss_base= get_tss_base();
++
++    ASSERT(tss_base);
++
++    if (0 == new_thread_syscall) {
++        tss_base->rsp0 = x86_get_syscall_stack();
++    } else {
++        tss_base->rsp0 = new_thread_syscall;
++    }
++
++    write_msr(SYSENTER_ESP_MSR, tss_base->rsp0);
+ }
+diff --git a/arch/x86/cache.c b/arch/x86/cache.c
+index 8f5cf5b..1e24b64 100644
+--- a/arch/x86/cache.c
++++ b/arch/x86/cache.c
+@@ -1,5 +1,6 @@
+ /*
+  * Copyright (c) 2009 Corey Tabaka
++ * Copyright (c) 2018 Intel Corporation
+  *
+  * Permission is hereby granted, free of charge, to any person obtaining
+  * a copy of this software and associated documentation files
+@@ -26,3 +27,15 @@
+ void arch_sync_cache_range(addr_t start, size_t len)
+ {
+ }
++
++void arch_clean_cache_range(addr_t start, size_t len)
++{
++}
++
++void arch_clean_invalidate_cache_range(addr_t start, size_t len)
++{
++}
++
++void arch_invalidate_cache_range(addr_t start, size_t len)
++{
++}
+diff --git a/arch/x86/descriptor.c b/arch/x86/descriptor.c
+index b9424f4..08d8d0f 100644
+--- a/arch/x86/descriptor.c
++++ b/arch/x86/descriptor.c
+@@ -1,5 +1,6 @@
+ /*
+  * Copyright (c) 2009 Corey Tabaka
++ * Copyright (c) 2017-2018 Intel Corporation
+  *
+  * Permission is hereby granted, free of charge, to any person obtaining
+  * a copy of this software and associated documentation files
+@@ -24,45 +25,64 @@
+ #include <compiler.h>
+ #include <arch/x86/descriptor.h>
+ 
+-/* not the best way to do this, but easy for now */
+-typedef struct {
+-    uint16_t limit_15_0;
+-    uint16_t base_15_0;
+-    uint8_t base_23_16;
++typedef union {
++    struct {
++        uint16_t limit_15_0;
++        uint16_t base_15_0;
++        uint8_t base_23_16;
+ 
+-    uint8_t type : 4;
+-    uint8_t s : 1;
+-    uint8_t dpl : 2;
+-    uint8_t p : 1;
++        uint8_t type : 4;
++        uint8_t s : 1;
++        uint8_t dpl : 2;
++        uint8_t p : 1;
+ 
+-    uint8_t limit_19_16 : 4;
+-    uint8_t avl : 1;
+-    uint8_t reserved_0 : 1;
+-    uint8_t d_b : 1;
+-    uint8_t g : 1;
++        uint8_t limit_19_16 : 4;
++        uint8_t avl : 1;
++        uint8_t reserved_0 : 1;
++        uint8_t d_b : 1;
++        uint8_t g : 1;
+ 
+-    uint8_t base_31_24;
++        uint8_t base_31_24;
++    } __PACKED seg_desc_legacy;
++    struct {
++        uint32_t base_32_63;
++        uint16_t rsvd_1;
++        uint16_t rsvd_2;
++    } __PACKED seg_desc_64_t;
+ } __PACKED seg_desc_t;
+ 
+ extern seg_desc_t _gdt[];
+ 
+-void set_global_desc(seg_sel_t sel, void *base, uint32_t limit,
+-                     uint8_t present, uint8_t ring, uint8_t sys, uint8_t type, uint8_t gran, uint8_t bits)
++void set_global_desc(seg_sel_t sel,
++        void *base,
++        uint32_t limit,
++        uint8_t present,
++        uint8_t ring,
++        uint8_t sys,
++        uint8_t type,
++        uint8_t gran,
++        uint8_t bits)
+ {
+-    // convert selector into index
++    /* convert selector into index */
+     uint16_t index = sel >> 3;
+ 
+-    _gdt[index].limit_15_0 = limit & 0x0000ffff;
+-    _gdt[index].limit_19_16 = (limit & 0x000f0000) >> 16;
++    _gdt[index].seg_desc_legacy.limit_15_0  = limit & 0x0000ffff;
++    _gdt[index].seg_desc_legacy.limit_19_16 = (limit & 0x000f0000) >> 16;
+ 
+-    _gdt[index].base_15_0 = ((uintptr_t) base) & 0x0000ffff;
+-    _gdt[index].base_23_16 = (((uintptr_t) base) & 0x00ff0000) >> 16;
+-    _gdt[index].base_31_24 = ((uintptr_t) base) >> 24;
++    _gdt[index].seg_desc_legacy.base_15_0   = ((uint64_t) base) & 0x0000ffff;
++    _gdt[index].seg_desc_legacy.base_23_16  = (((uint64_t) base) & 0x00ff0000) >> 16;
++    _gdt[index].seg_desc_legacy.base_31_24  = ((uint64_t) base) >> 24;
+ 
+-    _gdt[index].type = type & 0x0f; // segment type
+-    _gdt[index].p = present != 0;   // present
+-    _gdt[index].dpl = ring & 0x03;  // descriptor privilege level
+-    _gdt[index].g = gran != 0;      // granularity
+-    _gdt[index].s = sys != 0;       // system / non-system
+-    _gdt[index].d_b = bits != 0;    // 16 / 32 bit
++    _gdt[index].seg_desc_legacy.type = type & 0x0f;    // segment type
++    _gdt[index].seg_desc_legacy.p    = present != 0;   // present
++    _gdt[index].seg_desc_legacy.dpl  = ring & 0x03;    // descriptor privilege level
++    _gdt[index].seg_desc_legacy.g    = gran != 0;      // granularity
++    _gdt[index].seg_desc_legacy.s    = sys != 0;       // system / non-system
++    _gdt[index].seg_desc_legacy.d_b  = bits != 0;      // 16 / 32 bit
++
++    /* high bits of TSS */
++    if ((sel >= TSS_SELECTOR) && (sel <= TSS_SELECTOR + (SMP_MAX_CPUS - 1) * 0x10)) {
++        index = (sel + 8) >> 3;
++        _gdt[index].seg_desc_64_t.base_32_63 = ((uint64_t)base >> 32) & 0xffffffff;
++    }
+ }
+diff --git a/arch/x86/faults.c b/arch/x86/faults.c
+index b617eb5..7b82bc5 100644
+--- a/arch/x86/faults.c
++++ b/arch/x86/faults.c
+@@ -77,7 +77,7 @@
+ 
+ static void exception_die(x86_iframe_t *frame, const char *msg)
+ {
+-    dprintf(CRITICAL, msg);
++    dprintf(CRITICAL, "%s\n", msg);
+     dump_fault_frame(frame);
+ 
+     for (;;) {
+@@ -194,12 +194,6 @@
+ 
+         case INT_PAGE_FAULT:
+             x86_pfe_handler(frame);
+-            break;
+-
+-        case INT_DEV_NA_EX:
+-#if X86_WITH_FPU
+-            fpu_dev_na_handler();
+-#endif
+             break;
+ 
+         case INT_MF: { /* x87 floating point math fault */
+diff --git a/arch/x86/fpu.c b/arch/x86/fpu.c
+index 414fbfa..9ca6438 100644
+--- a/arch/x86/fpu.c
++++ b/arch/x86/fpu.c
+@@ -39,6 +39,7 @@
+ #define ECX_SSSE3   (0x00000001 << 9)
+ #define ECX_SSE4_1  (0x00000001 << 19)
+ #define ECX_SSE4_2  (0x00000001 << 20)
++#define ECX_OSXSAVE (0x00000001 << 27)
+ #define EDX_FXSR    (0x00000001 << 24)
+ #define EDX_SSE     (0x00000001 << 25)
+ #define EDX_SSE2    (0x00000001 << 26)
+@@ -53,11 +54,16 @@
+ 
+ #define FXSAVE_CAP(ecx, edx) ((edx & EDX_FXSR) != 0)
+ 
+-static int fp_supported;
+-static thread_t *fp_owner;
++#define OSXSAVE_CAP(ecx, edx) ((ecx & ECX_OSXSAVE) !=0 )
++
++static int fp_supported = 0;
+ 
+ /* FXSAVE area comprises 512 bytes starting with 16-byte aligned */
+-static uint8_t __ALIGNED(16) fpu_init_states[512]= {0};
++typedef struct _fpu_init_state {
++    uint8_t fpu_states[512];
++}fpu_init_states_t;
++
++static fpu_init_states_t __ALIGNED(16) fpu_init_states[SMP_MAX_CPUS];
+ 
+ static void get_cpu_cap(uint32_t *ecx, uint32_t *edx)
+ {
+@@ -72,15 +78,13 @@
+     uint32_t ecx = 0, edx = 0;
+     uint16_t fcw;
+     uint32_t mxcsr;
++    uint     cpu_id = arch_curr_cpu_num();
+ 
+ #ifdef ARCH_X86_64
+     uint64_t x;
+ #else
+     uint32_t x;
+ #endif
+-
+-    fp_supported = 0;
+-    fp_owner = NULL;
+ 
+     get_cpu_cap(&ecx, &edx);
+ 
+@@ -113,7 +117,9 @@
+     x = x86_get_cr4();
+     x |= X86_CR4_OSXMMEXPT;
+     x |= X86_CR4_OSFXSR;
+-    x &= ~X86_CR4_OSXSAVE;
++    if(OSXSAVE_CAP(ecx, edx)) {
++        x |= X86_CR4_OSXSAVE;
++    }
+     x86_set_cr4(x);
+ 
+     __asm__ __volatile__("stmxcsr %0" : "=m" (mxcsr));
+@@ -127,16 +133,17 @@
+     __asm__ __volatile__("ldmxcsr %0" : : "m" (mxcsr));
+ 
+     /* save fpu initial states, and used when new thread creates */
+-    __asm__ __volatile__("fxsave %0" : "=m" (fpu_init_states));
++    __asm__ __volatile__("fxsave %0" : "=m" (fpu_init_states[cpu_id].fpu_states));
+ 
+-    x86_set_cr0(x86_get_cr0() | X86_CR0_TS);
+     return;
+ }
+ 
+ void fpu_init_thread_states(thread_t *t)
+ {
++    uint cpu_id = arch_curr_cpu_num();
++
+     t->arch.fpu_states = (vaddr_t *)ROUNDUP(((vaddr_t)t->arch.fpu_buffer), 16);
+-    memcpy(t->arch.fpu_states, fpu_init_states, sizeof(fpu_init_states));
++    memcpy(t->arch.fpu_states, (const void *)fpu_init_states[cpu_id].fpu_states, sizeof(fpu_init_states_t));
+ }
+ 
+ void fpu_context_switch(thread_t *old_thread, thread_t *new_thread)
+@@ -144,34 +151,14 @@
+     if (fp_supported == 0)
+         return;
+ 
+-    if (new_thread != fp_owner)
+-        x86_set_cr0(x86_get_cr0() | X86_CR0_TS);
+-    else
+-        x86_set_cr0(x86_get_cr0() & ~X86_CR0_TS);
+-
+-    return;
+-}
+-
+-void fpu_dev_na_handler(void)
+-{
+-    thread_t *self;
+-
+-    x86_set_cr0(x86_get_cr0() & ~X86_CR0_TS);
+-
+-    if (fp_supported == 0)
+-        return;
+-
+-    self = get_current_thread();
+-
+-    LTRACEF("owner %p self %p\n", fp_owner, self);
+-    if ((fp_owner != NULL) && (fp_owner != self)) {
+-        __asm__ __volatile__("fxsave %0" : "=m" (*fp_owner->arch.fpu_states));
+-        __asm__ __volatile__("fxrstor %0" : : "m" (*self->arch.fpu_states));
++    if (old_thread) {
++        __asm__ __volatile__("fxsave %0" : "=m" (*old_thread->arch.fpu_states));
+     }
++    __asm__ __volatile__("fxrstor %0" : : "m" (*new_thread->arch.fpu_states));
+ 
+-    fp_owner = self;
+     return;
+ }
++
+ #endif
+ 
+ /* End of file */
+diff --git a/arch/x86/gdt.S b/arch/x86/gdt.S
+index c70dfe4..c37e20d 100644
+--- a/arch/x86/gdt.S
++++ b/arch/x86/gdt.S
+@@ -1,6 +1,6 @@
+ /*
+  * Copyright (c) 2009 Corey Tabaka
+- * Copyright (c) 2015 Intel Corporation
++ * Copyright (c) 2015-2018 Intel Corporation
+  * Copyright (c) 2016 Travis Geiselbrecht
+  *
+  * Permission is hereby granted, free of charge, to any person obtaining
+@@ -51,79 +51,96 @@
+     .int 0
+     .int 0
+ 
+-/* ring 0 descriptors */
+ .set codesel_32, . - _gdt
+ _code_32_gde:
+     .short 0xffff           /* limit 15:00 */
+     .short 0x0000           /* base 15:00 */
+-    .byte  0x00         /* base 23:16 */
++    .byte  0x00             /* base 23:16 */
+     .byte  0b10011010       /* P(1) DPL(00) S(1) 1 C(0) R(1) A(0) */
+     .byte  0b11001111       /* G(1) D(1) 0 0 limit 19:16 */
+-    .byte  0x0          /* base 31:24 */
++    .byte  0x0              /* base 31:24 */
+ 
+ .set datasel, . - _gdt
+ _data_gde:
+     .short 0xffff           /* limit 15:00 */
+     .short 0x0000           /* base 15:00 */
+-    .byte  0x00         /* base 23:16 */
++    .byte  0x00             /* base 23:16 */
+     .byte  0b10010010       /* P(1) DPL(00) S(1) 0 E(0) W(1) A(0) */
+     .byte  0b11001111       /* G(1) B(1) 0 0 limit 19:16 */
+-    .byte  0x0          /* base 31:24 */
++    .byte  0x0              /* base 31:24 */
+ 
+ .set user_codesel_32, . - _gdt
+ _user_code_32_gde:
+     .short 0xffff           /* limit 15:00 */
+     .short 0x0000           /* base 15:00 */
+-    .byte  0x00         /* base 23:16 */
++    .byte  0x00             /* base 23:16 */
+     .byte  0b11111010       /* P(1) DPL(11) S(1) 1 C(0) R(1) A(0) */
+     .byte  0b11001111       /* G(1) D(1) 0 0 limit 19:16 */
+-    .byte  0x0          /* base 31:24 */
++    .byte  0x0              /* base 31:24 */
+ 
+ 
+ .set user_datasel, . - _gdt
+ _user_data_32_gde:
+     .short 0xffff           /* limit 15:00 */
+     .short 0x0000           /* base 15:00 */
+-    .byte  0x00         /* base 23:16 */
++    .byte  0x00             /* base 23:16 */
+     .byte  0b11110010       /* P(1) DPL(11) S(1) 0 E(0) W(1) A(0) */
+     .byte  0b11001111       /* G(1) B(1) 0 0 limit 19:16 */
+-    .byte  0x0          /* base 31:24 */
++    .byte  0x0              /* base 31:24 */
+ 
+ .set codesel_64, . - _gdt
+ _code_64_gde:
+     .short 0xffff           /* limit 15:00 */
+     .short 0x0000           /* base 15:00 */
+-    .byte  0x00         /* base 23:16 */
++    .byte  0x00             /* base 23:16 */
+     .byte  0b10011010       /* P(1) DPL(00) S(1) 1 C(0) R(1) A(0) */
+     .byte  0b10101111       /* G(1) D(0) L(1) AVL(0) limit 19:16 */
+-    .byte  0x0          /* base 31:24 */
++    .byte  0x0              /* base 31:24 */
+ 
+ .set datasel_64, . - _gdt
+ _data_64_gde:
+     .short 0xffff           /* limit 15:00 */
+     .short 0x0000           /* base 15:00 */
+-    .byte  0x00         /* base 23:16 */
+-    .byte  0b10010010       /* P(1) DPL(00) S(1) 1 C(0) R(1) A(0) */
++    .byte  0x00             /* base 23:16 */
++    .byte  0b10010010       /* P(1) DPL(00) S(1) 1 E(0) W(1) A(0) */
+     .byte  0b11001111       /* G(1) B(1) 0 AVL(0) limit 19:16 */
+-    .byte  0x0          /* base 31:24 */
++    .byte  0x0              /* base 31:24 */
++
++.set user_codesel_compat, . - _gdt
++_user_code_compat_gde:
++    .short 0xffff           /* limit 15:00 */
++    .short 0x0000           /* base 15:00 */
++    .byte  0x00             /* base 23:16 */
++    .byte  0b11111010       /* P(1) DPL(11) S(1) 1 C(0) R(1) A(0) */
++    .byte  0b11001111       /* G(1) D(1) L(0) AVL(0) limit 19:16 */
++    .byte  0x0              /* base 31:24 */
++
++.set user_datasel_compat, . - _gdt
++_user_data_compat_gde:
++    .short 0xffff           /* limit 15:00 */
++    .short 0x0000           /* base 15:00 */
++    .byte  0x00             /* base 23:16 */
++    .byte  0b11110010       /* P(1) DPL(11) S(1) 0 E(0) W(1) A(0) */
++    .byte  0b11001111       /* G(1) B(1) 0 0 limit 19:16 */
++    .byte  0x0              /* base 31:24 */
+ 
+ .set user_codesel_64, . - _gdt
+ _user_code_64_gde:
+     .short 0xffff           /* limit 15:00 */
+     .short 0x0000           /* base 15:00 */
+-    .byte  0x00         /* base 23:16 */
++    .byte  0x00             /* base 23:16 */
+     .byte  0b11111010       /* P(1) DPL(11) S(1) 1 C(0) R(1) A(0) */
+-    .byte  0b10101111       /* G(1) D(1) L(0) AVL(0) limit 19:16 */
+-    .byte  0x0          /* base 31:24 */
++    .byte  0b10101111       /* G(1) D(0) L(1) AVL(0) limit 19:16 */
++    .byte  0x0              /* base 31:24 */
+ 
+ .set user_datasel_64, . - _gdt
+ _user_data_64_gde:
+     .short 0xffff           /* limit 15:00 */
+     .short 0x0000           /* base 15:00 */
+-    .byte  0x00         /* base 23:16 */
++    .byte  0x00             /* base 23:16 */
+     .byte  0b11110010       /* P(1) DPL(11) S(1) 0 E(0) W(1) A(0) */
+     .byte  0b11001111       /* G(1) B(1) 0 0 limit 19:16 */
+-    .byte  0x0          /* base 31:24 */
++    .byte  0x0              /* base 31:24 */
+ 
+ /* TSS descriptor */
+ .set tsssel, . - _gdt
+@@ -131,9 +148,9 @@
+     .short 0                /* limit 15:00 */
+     .short 0                /* base 15:00 */
+     .byte  0                /* base 23:16 */
+-    .byte  0x89             /* P(1) DPL(11) 0 10 B(0) 1 */
+-    .byte  0x80             /* G(0) 0 0 AVL(0) limit 19:16 */
+-    .byte  0               /* base 31:24 */
++    .byte  0x89             /* P(1) DPL(0) S(0) TYPE(9) */
++    .byte  0x80             /* G(1) 0 0 AVL(0) limit 19:16 */
++    .byte  0                /* base 31:24 */
+     .quad  0x0000000000000000
+ 
+ DATA(_gdt_end)
+diff --git a/arch/x86/include/arch/arch_ops.h b/arch/x86/include/arch/arch_ops.h
+index 5ad97b1..b786075 100644
+--- a/arch/x86/include/arch/arch_ops.h
++++ b/arch/x86/include/arch/arch_ops.h
+@@ -1,6 +1,7 @@
+ /*
+  * Copyright (c) 2009 Corey Tabaka
+  * Copyright (c) 2014 Travis Geiselbrecht
++ * Copyright (c) 2018 Intel Corporation
+  *
+  * Permission is hereby granted, free of charge, to any person obtaining
+  * a copy of this software and associated documentation files
+@@ -28,6 +29,7 @@
+ #ifndef ASSEMBLY
+ 
+ #include <arch/x86.h>
++#include <arch/x86/mp.h>
+ 
+ /* override of some routines */
+ static inline void arch_enable_ints(void)
+@@ -39,6 +41,16 @@
+ static inline void arch_disable_ints(void)
+ {
+     __asm__ volatile("cli");
++    CF;
++}
++
++static inline void arch_enable_fiqs(void)
++{
++    CF;
++}
++
++static inline void arch_disable_fiqs(void)
++{
+     CF;
+ }
+ 
+@@ -89,9 +101,30 @@
+ }
+ 
+ 
++#if ARCH_X86_32
+ static inline int atomic_and(volatile int *ptr, int val) { return _atomic_and(ptr, val); }
+ static inline int atomic_or(volatile int *ptr, int val) { return _atomic_or(ptr, val); }
+ static inline int atomic_cmpxchg(volatile int *ptr, int oldval, int newval) { return _atomic_cmpxchg(ptr, oldval, newval); }
++#elif ARCH_X86_64
++static inline int atomic_and(volatile int *ptr, long val) { return _atomic_and(ptr, val); }
++static inline int atomic_or(volatile int *ptr, long val) { return _atomic_or(ptr, val); }
++static inline int atomic_cmpxchg(volatile int *ptr, int oldval, uint64_t newval)
++{
++#if USE_GCC_ATOMICS
++    __atomic_compare_exchange_n(ptr, &oldval, newval, false,
++            __ATOMIC_RELAXED, __ATOMIC_RELAXED);
++
++#else
++    __asm__ volatile(
++        "lock cmpxchgq  %[newval], %[ptr];"
++        : "=a" (oldval),  "=m" (*ptr)
++        : "a" (oldval), [newval]"r" (newval), [ptr]"m" (*ptr)
++        : "memory"
++    );
++#endif
++    return oldval;
++}
++#endif
+ 
+ static inline uint32_t arch_cycle_count(void)
+ {
+@@ -101,17 +134,14 @@
+     return timestamp;
+ }
+ 
+-/* use a global pointer to store the current_thread */
+-extern struct thread *_current_thread;
+-
+ static inline struct thread *get_current_thread(void)
+ {
+-    return _current_thread;
++    return (struct thread *)x86_get_current_thread();
+ }
+ 
+ static inline void set_current_thread(struct thread *t)
+ {
+-    _current_thread = t;
++    x86_set_current_thread((void *)t);
+ }
+ 
+ static inline uint arch_curr_cpu_num(void)
+@@ -119,4 +149,19 @@
+     return 0;
+ }
+ 
++#define mb()        __asm__ volatile ("mfence":::"memory");
++#define wmb()       __asm__ volatile ("sfence":::"memory");
++#define rmb()       __asm__ volatile ("lfence":::"memory");
++
++#ifdef WITH_SMP
++#define smp_mb()    mb()
++#define smp_wmb()   wmb()
++#define smp_rmb()   rmb()
++#else
++#define smp_mb()    mb()
++#define smp_wmb()   wmb()
++#define smp_rmb()   rmb()
++#endif
++
++
+ #endif // !ASSEMBLY
+diff --git a/arch/x86/include/arch/arch_thread.h b/arch/x86/include/arch/arch_thread.h
+index bd970a4..0882db9 100644
+--- a/arch/x86/include/arch/arch_thread.h
++++ b/arch/x86/include/arch/arch_thread.h
+@@ -1,6 +1,6 @@
+ /*
+  * Copyright (c) 2009 Corey Tabaka
+- * Copyright (c) 2015 Intel Corporation
++ * Copyright (c) 2015-2018 Intel Corporation
+  *
+  * Permission is hereby granted, free of charge, to any person obtaining
+  * a copy of this software and associated documentation files
+@@ -25,6 +25,23 @@
+ 
+ #include <sys/types.h>
+ 
++#define CF_MASK         0x0000
++#define PA_MASK         0x0001
++#define PF_MASK         0x0020
++#define TF_MASK         0x0100
++#define IF_MASK         0x0200
++#define IOPL_MASK       0x3000
++#define NTi_MASK        0x4000
++#define RSVD            0x0002
++
++/* 0x3202 */
++#define USER_EFLAGS (IF_MASK|IOPL_MASK|RSVD)
++
++/* SYSCALL Handling */
++#define SYSENTER_CS_MSR    0x174
++#define SYSENTER_ESP_MSR   0x175
++#define SYSENTER_EIP_MSR   0x176
++
+ struct arch_thread {
+     vaddr_t sp;
+ #if X86_WITH_FPU
+diff --git a/arch/x86/include/arch/aspace.h b/arch/x86/include/arch/aspace.h
+index 3c82778..a494a66 100644
+--- a/arch/x86/include/arch/aspace.h
++++ b/arch/x86/include/arch/aspace.h
+@@ -1,5 +1,6 @@
+ /*
+  * Copyright (c) 2016 Travis Geiselbrecht
++ * Copyright (c) 2018 Intel Corporation
+  *
+  * Permission is hereby granted, free of charge, to any person obtaining
+  * a copy of this software and associated documentation files
+@@ -23,11 +24,14 @@
+ #pragma once
+ 
+ #include <compiler.h>
++#include <sys/types.h>
+ 
+ __BEGIN_CDECLS
+ 
+ struct arch_aspace {
+-    // nothing for now, does not support address spaces other than the kernel
++    paddr_t page_table;
++    vaddr_t base;
++    size_t  size;
+ };
+ 
+ __END_CDECLS
+diff --git a/arch/x86/include/arch/local_apic.h b/arch/x86/include/arch/local_apic.h
+new file mode 100644
+index 0000000..9c38bea
+--- /dev/null
++++ b/arch/x86/include/arch/local_apic.h
+@@ -0,0 +1,36 @@
++/*
++ * Copyright (c) 2018 Intel Corporation
++ *
++ * Permission is hereby granted, free of charge, to any person obtaining
++ * a copy of this software and associated documentation files
++ * (the "Software"), to deal in the Software without restriction,
++ * including without limitation the rights to use, copy, modify, merge,
++ * publish, distribute, sublicense, and/or sell copies of the Software,
++ * and to permit persons to whom the Software is furnished to do so,
++ * subject to the following conditions:
++ *
++ * The above copyright notice and this permission notice shall be
++ * included in all copies or substantial portions of the Software.
++ *
++ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
++ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
++ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
++ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
++ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
++ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
++ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
++ */
++#pragma once
++
++#include <compiler.h>
++#include <sys/types.h>
++#include <stdlib.h>
++#include <stdbool.h>
++
++void lapic_id_init(void);
++void local_apic_init(void);
++void lapic_eoi(void);
++void lapic_software_disable(void);
++bool send_self_ipi(uint32_t vector);
++void local_apic_reinit(void);
++bool local_apic_vector_in_service(uint32_t vector);
+diff --git a/arch/x86/include/arch/spinlock.h b/arch/x86/include/arch/spinlock.h
+index b641113..203c80a 100644
+--- a/arch/x86/include/arch/spinlock.h
++++ b/arch/x86/include/arch/spinlock.h
+@@ -1,5 +1,6 @@
+ /*
+  * Copyright (c) 2015 Travis Geiselbrecht
++ * Copyright (c) 2018 Intel Corporation
+  *
+  * Permission is hereby granted, free of charge, to any person obtaining
+  * a copy of this software and associated documentation files
+@@ -28,6 +29,10 @@
+ 
+ #define SPIN_LOCK_INITIAL_VALUE (0)
+ 
++/* flags are unused on x86 */
++#define ARCH_DEFAULT_SPIN_LOCK_FLAG_INTERRUPTS  0
++#define SPIN_LOCK_FLAG_IRQ    ARCH_DEFAULT_SPIN_LOCK_FLAG_INTERRUPTS
++#define SPIN_LOCK_FLAG_IRQ_FIQ    ARCH_DEFAULT_SPIN_LOCK_FLAG_INTERRUPTS
+ typedef unsigned long spin_lock_t;
+ 
+ typedef x86_flags_t spin_lock_saved_state_t;
+diff --git a/arch/x86/include/arch/x86.h b/arch/x86/include/arch/x86.h
+index 2e7087e..f6c73c0 100644
+--- a/arch/x86/include/arch/x86.h
++++ b/arch/x86/include/arch/x86.h
+@@ -1,6 +1,6 @@
+ /*
+  * Copyright (c) 2009 Corey Tabaka
+- * Copyright (c) 2015 Intel Corporation
++ * Copyright (c) 2015-2018 Intel Corporation
+  * Copyright (c) 2016 Travis Geiselbrecht
+  *
+  * Permission is hereby granted, free of charge, to any person obtaining
+@@ -136,24 +136,27 @@
+ typedef tss_64_t tss_t;
+ #endif
+ 
+-#define X86_CR0_PE 0x00000001 /* protected mode enable */
+-#define X86_CR0_MP 0x00000002 /* monitor coprocessor */
+-#define X86_CR0_EM 0x00000004 /* emulation */
+-#define X86_CR0_TS 0x00000008 /* task switched */
+-#define X86_CR0_NE 0x00000020 /* enable x87 exception */
+-#define X86_CR0_WP 0x00010000 /* supervisor write protect */
+-#define X86_CR0_NW 0x20000000 /* not write-through */
+-#define X86_CR0_CD 0x40000000 /* cache disable */
+-#define X86_CR0_PG 0x80000000 /* enable paging */
+-#define X86_CR4_PAE 0x00000020 /* PAE paging */
+-#define X86_CR4_OSFXSR 0x00000200 /* os supports fxsave */
+-#define X86_CR4_OSXMMEXPT 0x00000400 /* os supports xmm exception */
+-#define X86_CR4_OSXSAVE 0x00040000 /* os supports xsave */
+-#define X86_CR4_SMEP 0x00100000 /* SMEP protection enabling */
+-#define X86_CR4_SMAP 0x00200000 /* SMAP protection enabling */
+-#define x86_EFER_NXE 0x00000800 /* to enable execute disable bit */
+-#define x86_MSR_EFER 0xc0000080 /* EFER Model Specific Register id */
+-#define X86_CR4_PSE 0xffffffef /* Disabling PSE bit in the CR4 */
++#define X86_CR0_PE              0x00000001 /* protected mode enable */
++#define X86_CR0_MP              0x00000002 /* monitor coprocessor */
++#define X86_CR0_EM              0x00000004 /* emulation */
++#define X86_CR0_TS              0x00000008 /* task switched */
++#define X86_CR0_NE              0x00000020 /* enable x87 exception */
++#define X86_CR0_WP              0x00010000 /* supervisor write protect */
++#define X86_CR0_NW              0x20000000 /* not write-through */
++#define X86_CR0_CD              0x40000000 /* cache disable */
++#define X86_CR0_PG              0x80000000 /* enable paging */
++#define X86_CR4_PAE             0x00000020 /* PAE paging */
++#define X86_CR4_OSFXSR          0x00000200 /* os supports fxsave */
++#define X86_CR4_OSXMMEXPT       0x00000400 /* os supports xmm exception */
++#define X86_CR4_FSGSBASE        0x00010000 /* FSGSBASE enable bit */
++#define X86_CR4_OSXSAVE         0x00040000 /* os supports xsave */
++#define X86_CR4_SMEP            0x00100000 /* SMEP protection enabling */
++#define X86_CR4_SMAP            0x00200000 /* SMAP protection enabling */
++#define X86_EFER_NXE            0x00000800 /* to enable execute disable bit */
++#define X86_MSR_EFER            0xc0000080 /* EFER Model Specific Register id */
++#define X86_MSR_GS_BASE         0xc0000101 /* Map of base address of GS */
++#define X86_MSR_KRNL_GS_BASE    0xc0000102 /* Swap target of base address of GS */
++#define X86_CR4_PSE             0xffffffef /* Disabling PSE bit in the CR4 */
+ 
+ #if ARCH_X86_32
+ static inline void set_in_cr0(uint32_t mask)
+@@ -497,7 +500,7 @@
+         "cpuid \n\t"
+         :"=b" (reg_b)
+         :"a" (reg_a),"c" (reg_c));
+-    return ((reg_b>>0x06) & 0x1);
++    return ((reg_b>>0x07) & 0x1);
+ }
+ 
+ static inline uint32_t check_smap_avail(void)
+@@ -509,7 +512,7 @@
+         "cpuid \n\t"
+         :"=b" (reg_b)
+         :"a" (reg_a),"c" (reg_c));
+-    return ((reg_b>>0x13) & 0x1);
++    return ((reg_b>>0x14) & 0x1);
+ }
+ #endif // ARCH_X86_32
+ 
+@@ -828,7 +831,7 @@
+         "cpuid \n\t"
+         :"=b" (reg_b)
+         :"a" (reg_a),"c" (reg_c));
+-    return ((reg_b>>0x06) & 0x1);
++    return ((reg_b>>0x07) & 0x1);
+ }
+ 
+ static inline uint64_t check_smap_avail(void)
+@@ -840,9 +843,42 @@
+         "cpuid \n\t"
+         :"=b" (reg_b)
+         :"a" (reg_a),"c" (reg_c));
+-    return ((reg_b>>0x13) & 0x1);
++    return ((reg_b>>0x14) & 0x1);
+ }
+ 
++static inline uint64_t check_fsgsbase_avail(void)
++{
++    uint64_t reg_a = 0x07;
++    uint64_t reg_b = 0x0;
++    uint64_t reg_c = 0x0;
++    __asm__ __volatile__ (
++        "cpuid \n\t"
++        :"=b" (reg_b)
++        :"a" (reg_a),"c" (reg_c));
++    return (reg_b & 0x1);
++}
++
++static inline uint64_t x86_read_gs_with_offset(uintptr_t offset)
++{
++    uint64_t ret;
++    __asm__ __volatile__ (
++        "movq  %%gs:%1, %0"
++        :"=r" (ret)
++        :"m" (*(uint64_t *)offset));
++    return ret;
++}
++
++static inline void x86_write_gs_with_offset(uint64_t offset, uint64_t val)
++{
++    __asm__ __volatile__ (
++        "movq  %0, %%gs:%1"
++        :
++        :"ir" (val), "m" (*(uint64_t *)offset)
++        :"memory");
++}
++
++void *get_tss_base(void);
++
+ #endif // ARCH_X86_64
+ 
+ __END_CDECLS
+diff --git a/arch/x86/include/arch/x86/descriptor.h b/arch/x86/include/arch/x86/descriptor.h
+index 832c2c4..91e7c44 100644
+--- a/arch/x86/include/arch/x86/descriptor.h
++++ b/arch/x86/include/arch/x86/descriptor.h
+@@ -1,6 +1,6 @@
+ /*
+  * Copyright (c) 2009 Corey Tabaka
+- * Copyright (c) 2014 Intel Corporation
++ * Copyright (c) 2018 Intel Corporation
+  *
+  * Permission is hereby granted, free of charge, to any person obtaining
+  * a copy of this software and associated documentation files
+@@ -29,18 +29,20 @@
+ #define NULL_SELECTOR       0x00
+ 
+ /********* x86 selectors *********/
+-#define CODE_SELECTOR       0x08
+-#define DATA_SELECTOR       0x10
+-#define USER_CODE_32_SELECTOR   0x18
+-#define USER_DATA_32_SELECTOR   0x20
++#define CODE_SELECTOR                   0x08
++#define DATA_SELECTOR                   0x10
++#define USER_CODE_32_SELECTOR           0x18
++#define USER_DATA_32_SELECTOR           0x20
+ 
+ /******* x86-64 selectors ********/
+-#define CODE_64_SELECTOR    0x28
+-#define STACK_64_SELECTOR   0x30
+-#define USER_CODE_64_SELECTOR   0x38
+-#define USER_DATA_64_SELECTOR   0x40
++#define CODE_64_SELECTOR                0x28
++#define STACK_64_SELECTOR               0x30
++#define USER_CODE_COMPAT_SELECTOR       0x38
++#define USER_DATA_COMPAT_SELECTOR       0x40
++#define USER_CODE_64_SELECTOR           0x48
++#define USER_DATA_64_SELECTOR           0x50
+ 
+-#define TSS_SELECTOR        0x48
++#define TSS_SELECTOR                    0x58
+ 
+ /*
+  * Descriptor Types
+@@ -52,13 +54,22 @@
+ #define SEG_TYPE_DATA_RW    0x2
+ #define SEG_TYPE_CODE_RW    0xa
+ 
++#define USER_RPL            0x03
++
+ #ifndef ASSEMBLY
+ 
+ #include <sys/types.h>
+ 
+ typedef uint16_t seg_sel_t;
+ 
+-void set_global_desc(seg_sel_t sel, void *base, uint32_t limit,
+-                     uint8_t present, uint8_t ring, uint8_t sys, uint8_t type, uint8_t gran, uint8_t bits);
++void set_global_desc(seg_sel_t sel,
++                        void *base,
++                        uint32_t limit,
++                        uint8_t present,
++                        uint8_t ring,
++                        uint8_t sys,
++                        uint8_t type,
++                        uint8_t gran,
++                        uint8_t bits);
+ 
+ #endif
+diff --git a/arch/x86/include/arch/x86/mmu.h b/arch/x86/include/arch/x86/mmu.h
+index b71cdc6..9722a59 100644
+--- a/arch/x86/include/arch/x86/mmu.h
++++ b/arch/x86/include/arch/x86/mmu.h
+@@ -1,6 +1,6 @@
+ /*
+  * Copyright (c) 2008 Travis Geiselbrecht
+- * Copyright (c) 2015 Intel Corporation
++ * Copyright (c) 2015-2018 Intel Corporation
+  *
+  * Permission is hereby granted, free of charge, to any person obtaining
+  * a copy of this software and associated documentation files
+@@ -32,6 +32,8 @@
+ #define X86_MMU_PG_P        0x001           /* P    Valid                   */
+ #define X86_MMU_PG_RW       0x002           /* R/W  Read/Write              */
+ #define X86_MMU_PG_U        0x004           /* U/S  User/Supervisor         */
++#define X86_MMU_PG_PWT      0x008           /* PWT  cache bit               */
++#define X86_MMU_PG_PCD      0x010           /* PCD  cacke bit               */
+ #define X86_MMU_PG_PS       0x080           /* PS   Page size (0=4k,1=4M)   */
+ #define X86_MMU_PG_PTE_PAT  0x080           /* PAT  PAT index               */
+ #define X86_MMU_PG_G        0x100           /* G    Global                  */
+@@ -52,7 +54,7 @@
+ /* PAE mode */
+ #define X86_PDPT_ADDR_MASK  (0x00000000ffffffe0ul)
+ #define X86_PG_FRAME        (0xfffffffffffff000ul)
+-#define X86_PHY_ADDR_MASK   (0x000ffffffffffffful)
++#define X86_PHY_ADDR_MASK   (0x000ffffffffffffful)  /* ISDM:4.1.4 MAXPHYADDR is at most 52 */
+ #define X86_FLAGS_MASK      (0x0000000000000ffful)  /* NX Bit is ignored in the PAE mode */
+ #define X86_PTE_NOT_PRESENT (0xFFFFFFFFFFFFFFFEul)
+ #define X86_2MB_PAGE_FRAME  (0x000fffffffe00000ul)
+diff --git a/arch/x86/include/arch/x86/mp.h b/arch/x86/include/arch/x86/mp.h
+new file mode 100644
+index 0000000..b6b6455
+--- /dev/null
++++ b/arch/x86/include/arch/x86/mp.h
+@@ -0,0 +1,55 @@
++/*
++ * Copyright (c) 2018 Intel Corporation
++ *
++ * Permission is hereby granted, free of charge, to any person obtaining
++ * a copy of this software and associated documentation files
++ * (the "Software"), to deal in the Software without restriction,
++ * including without limitation the rights to use, copy, modify, merge,
++ * publish, distribute, sublicense, and/or sell copies of the Software,
++ * and to permit persons to whom the Software is furnished to do so,
++ * subject to the following conditions:
++ *
++ * The above copyright notice and this permission notice shall be
++ * included in all copies or substantial portions of the Software.
++ *
++ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
++ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
++ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
++ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
++ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
++ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
++ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
++ */
++#pragma once
++
++#include <arch/x86.h>
++
++typedef struct x86_global_state {
++    void *cur_thread;
++    uint64_t syscall_stack;
++} x86_global_states_t;
++
++#define CUR_THREAD_OFFSET       __offsetof(struct x86_global_state, cur_thread)
++#define SYSACLL_STACK_OFFSET    __offsetof(struct x86_global_state, syscall_stack)
++
++extern x86_global_states_t global_state[SMP_MAX_CPUS];
++
++static inline void * x86_get_current_thread(void)
++{
++    return (void *)x86_read_gs_with_offset(CUR_THREAD_OFFSET);
++}
++
++static inline void x86_set_current_thread(void *cur_thread)
++{
++    x86_write_gs_with_offset(CUR_THREAD_OFFSET, (uint64_t)cur_thread);
++}
++
++static inline uint64_t x86_get_syscall_stack(void)
++{
++    return x86_read_gs_with_offset(SYSACLL_STACK_OFFSET);
++}
++
++static inline void x86_set_syscall_stack(uint64_t stack)
++{
++    x86_write_gs_with_offset(SYSACLL_STACK_OFFSET, stack);
++}
+diff --git a/arch/x86/local_apic.c b/arch/x86/local_apic.c
+new file mode 100644
+index 0000000..434cc0a
+--- /dev/null
++++ b/arch/x86/local_apic.c
+@@ -0,0 +1,190 @@
++/*
++ * Copyright (c) 2018 Intel Corporation
++ *
++ * Permission is hereby granted, free of charge, to any person obtaining
++ * a copy of this software and associated documentation files
++ * (the "Software"), to deal in the Software without restriction,
++ * including without limitation the rights to use, copy, modify, merge,
++ * publish, distribute, sublicense, and/or sell copies of the Software,
++ * and to permit persons to whom the Software is furnished to do so,
++ * subject to the following conditions:
++ *
++ * The above copyright notice and this permission notice shall be
++ * included in all copies or substantial portions of the Software.
++ *
++ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
++ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
++ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
++ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
++ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
++ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
++ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
++ */
++#include <stdint.h>
++#include <assert.h>
++#include <arch/x86.h>
++#include <arch/x86/mmu.h>
++#include <arch/arch_ops.h>
++#include <arch/local_apic.h>
++#include <kernel/vm.h>
++#include <bits.h>
++
++#ifdef EPT_DEBUG
++#include <platform/vmcall.h>
++#endif
++
++typedef enum {
++    LAPIC_ID_REG            = 0x2,
++    LAPIC_EOI               = 0xB,
++    LAPIC_SIVR              = 0xF,
++    LAPIC_ISR0              = 0x10,
++    LAPIC_INTR_CMD_REG      = 0x30, /* 64-bits in x2APIC */
++    LAPIC_INTR_CMD_HI_REG   = 0x31, /* not available in x2APIC */
++    LAPIC_SELF_IPI_REG      = 0x3F  /* not available in xAPIC */
++} lapic_reg_id_t;
++
++#define PAGE_4K_MASK 0xfffULL
++
++#define MSR_APIC_BASE       0x1B
++#define LAPIC_ENABLED       (1ULL << 11)
++#define LAPIC_X2_ENABLED    (1ULL << 10)
++#define LAPIC_BASE_ADDR(base_msr) ((base_msr) & (~PAGE_4K_MASK))
++
++/* deliver status bit 12. 0 idle, 1 send pending. */
++#define APIC_DS_BIT         (1ULL << 12)
++#define MSR_X2APIC_BASE     0x800
++
++#define APIC_DM_FIXED       0x000
++#define APIC_LEVEL_ASSERT   0x4000
++#define APIC_DEST_SELF      0x40000
++
++static volatile uint64_t lapic_base_virtual_addr = 0;
++
++static uint32_t lapic_x1_read_reg(lapic_reg_id_t reg_id)
++{
++    DEBUG_ASSERT(lapic_base_virtual_addr);
++    uint64_t addr = lapic_base_virtual_addr + (uint64_t)(reg_id << 4);
++
++    return *(volatile uint32_t*)(addr);
++}
++
++static void lapic_x1_write_reg(lapic_reg_id_t reg_id, uint32_t data)
++{
++    DEBUG_ASSERT(lapic_base_virtual_addr);
++    uint64_t addr = lapic_base_virtual_addr + (uint64_t)(reg_id << 4);
++
++    *(volatile uint32_t*)addr = data;
++}
++
++/* caller must make sure xAPIC mode. */
++static void lapic_x1_wait_for_ipi(void)
++{
++    uint32_t icr_low;
++
++    while (1) {
++        icr_low = lapic_x1_read_reg(LAPIC_INTR_CMD_REG);
++        if ((icr_low & APIC_DS_BIT) == 0)
++            break;
++    }
++}
++
++static uint64_t lapic_x2_read_reg(lapic_reg_id_t reg_id)
++{
++    return read_msr(MSR_X2APIC_BASE + reg_id);
++}
++
++static void lapic_x2_write_reg(lapic_reg_id_t reg_id, uint64_t data)
++{
++    write_msr(MSR_X2APIC_BASE + reg_id, data);
++}
++
++void local_apic_init(void)
++{
++    uint64_t lapic_base_phy_addr = read_msr(MSR_APIC_BASE);
++
++/*
++ * Hard code mapping here, at this point, memory manager has not
++ * been initialized yet, cannot use vmm_alloc_physical().
++ * lapic_base_virtual_addr has been covered by 64 GB mapping here.
++ */
++    lapic_base_phy_addr = LAPIC_BASE_ADDR(lapic_base_phy_addr);
++    lapic_base_virtual_addr =  KERNEL_ASPACE_BASE + lapic_base_phy_addr;
++
++#ifdef EPT_DEBUG
++	make_ept_update_vmcall(ADD, lapic_base_phy_addr, PAGE_SIZE);
++#endif
++}
++
++void lapic_eoi(void)
++{
++    lapic_x1_write_reg(LAPIC_EOI, 1);
++}
++
++void lapic_software_disable(void)
++{
++    lapic_x1_write_reg(LAPIC_SIVR, 0xFF);
++}
++
++bool send_self_ipi(uint32_t vector)
++{
++    uint32_t icr_low;
++    uint64_t apic_base_msr = read_msr(MSR_APIC_BASE);
++
++    if (!(apic_base_msr & LAPIC_ENABLED)) {
++        return false;
++    }
++
++    icr_low = APIC_DEST_SELF | APIC_LEVEL_ASSERT | APIC_DM_FIXED | vector;
++
++    if (apic_base_msr & LAPIC_X2_ENABLED) {
++        lapic_x2_write_reg(LAPIC_SELF_IPI_REG, (uint64_t)vector);
++    } else {
++        lapic_x1_wait_for_ipi();
++        lapic_x1_write_reg(LAPIC_INTR_CMD_REG, icr_low);
++    }
++
++    return true;
++}
++
++
++/* Remap Local API instead of hard code mapping */
++void local_apic_reinit(void)
++{
++    status_t ret;
++    uint64_t lapic_base_phy_addr = read_msr(MSR_APIC_BASE);
++
++    lapic_base_phy_addr = LAPIC_BASE_ADDR(lapic_base_phy_addr);
++    ret = vmm_alloc_physical(vmm_get_kernel_aspace(),
++            "lapic",
++            4096,
++            (void **)&lapic_base_virtual_addr,
++            PAGE_SIZE_SHIFT,
++            lapic_base_phy_addr,
++            0,
++            ARCH_MMU_FLAG_UNCACHED_DEVICE);
++
++    if (ret) {
++        dprintf(CRITICAL, "Failed to allocate memory for Local APIC!\n");
++        return;
++    }
++}
++
++bool local_apic_vector_in_service(uint32_t vector)
++{
++    uint32_t idx = vector / 32;
++    uint32_t bit = vector % 32;
++    uint64_t apic_base_msr = read_msr(MSR_APIC_BASE);
++    uint64_t val;
++
++    if (!(apic_base_msr & LAPIC_ENABLED)) {
++        return false;
++    }
++
++    if (apic_base_msr & LAPIC_X2_ENABLED) {
++        val = lapic_x2_read_reg(LAPIC_ISR0 + idx);
++    } else {
++        val = (uint64_t)lapic_x1_read_reg(LAPIC_ISR0 + idx);
++    }
++
++    return !!BIT(val, bit);
++}
+diff --git a/arch/x86/rules.mk b/arch/x86/rules.mk
+index e26dfb9..b14afff 100644
+--- a/arch/x86/rules.mk
++++ b/arch/x86/rules.mk
+@@ -24,8 +24,8 @@
+ KERNEL_LOAD_OFFSET ?= 0x00200000
+ KERNEL_ASPACE_BASE ?= 0xffffff8000000000UL # -512GB
+ KERNEL_ASPACE_SIZE ?= 0x0000008000000000UL
+-USER_ASPACE_BASE   ?= 0x0000000000000000UL
+-USER_ASPACE_SIZE   ?= 0x0000800000000000UL
++USER_ASPACE_BASE   ?= 0x0000000000001000UL
++USER_ASPACE_SIZE   ?= 0x00007FFFFFFFF000UL
+ SUBARCH_DIR := $(LOCAL_DIR)/64
+ endif
+ 
+@@ -38,6 +38,8 @@
+ 	KERNEL_LOAD_OFFSET=$(KERNEL_LOAD_OFFSET) \
+ 	KERNEL_ASPACE_BASE=$(KERNEL_ASPACE_BASE) \
+ 	KERNEL_ASPACE_SIZE=$(KERNEL_ASPACE_SIZE) \
++	USER_ASPACE_BASE=$(USER_ASPACE_BASE) \
++	USER_ASPACE_SIZE=$(USER_ASPACE_SIZE) \
+ 	SMP_MAX_CPUS=1 \
+ 	X86_WITH_FPU=1
+ 
+@@ -47,14 +49,19 @@
+ 	$(SUBARCH_DIR)/exceptions.S \
+ 	$(SUBARCH_DIR)/mmu.c \
+ 	$(SUBARCH_DIR)/ops.S \
+-\
++	$(SUBARCH_DIR)/usercopy.c \
+ 	$(LOCAL_DIR)/arch.c \
+ 	$(LOCAL_DIR)/cache.c \
+ 	$(LOCAL_DIR)/gdt.S \
+ 	$(LOCAL_DIR)/thread.c \
+ 	$(LOCAL_DIR)/faults.c \
+ 	$(LOCAL_DIR)/descriptor.c \
+-	$(LOCAL_DIR)/fpu.c
++	$(LOCAL_DIR)/fpu.c \
++	$(LOCAL_DIR)/local_apic.c
++
++ifeq (true, $(WITH_CUSTOMIZED_BOOTSTRAP))
++	MODULE_SRCS := $(filter-out $(SUBARCH_DIR)/start.S, $(MODULE_SRCS))
++endif
+ 
+ include $(LOCAL_DIR)/toolchain.mk
+ 
+@@ -74,6 +81,9 @@
+ $(warning ARCH_x86_64_TOOLCHAIN_PREFIX = $(ARCH_x86_64_TOOLCHAIN_PREFIX))
+ $(warning TOOLCHAIN_PREFIX = $(TOOLCHAIN_PREFIX))
+ 
++ifeq ($(call TOBOOL,$(CLANGBUILD)), true)
++ARCH_COMPILEFLAGS += $(ARCH_$(ARCH)_COMPILEFLAGS)
++endif
+ 
+ cc-option = $(shell if test -z "`$(1) $(2) -S -o /dev/null -xc /dev/null 2>&1`"; \
+ 	then echo "$(2)"; else echo "$(3)"; fi ;)
+@@ -84,6 +94,7 @@
+ GLOBAL_COMPILEFLAGS += -fasynchronous-unwind-tables
+ GLOBAL_COMPILEFLAGS += -gdwarf-2
+ GLOBAL_COMPILEFLAGS += -fno-pic
++GLOBAL_COMPILEFLAGS += -msoft-float
+ GLOBAL_LDFLAGS += -z max-page-size=4096
+ 
+ ifeq ($(SUBARCH),x86-64)
+diff --git a/arch/x86/thread.c b/arch/x86/thread.c
+index e75f199..85eb57f 100644
+--- a/arch/x86/thread.c
++++ b/arch/x86/thread.c
+@@ -1,7 +1,7 @@
+ /*
+  * Copyright (c) 2009 Corey Tabaka
+  * Copyright (c) 2014 Travis Geiselbrecht
+- * Copyright (c) 2015 Intel Corporation
++ * Copyright (c) 2015-2018 Intel Corporation
+  *
+  * Permission is hereby granted, free of charge, to any person obtaining
+  * a copy of this software and associated documentation files
+@@ -32,19 +32,17 @@
+ #include <arch/x86/descriptor.h>
+ #include <arch/fpu.h>
+ 
+-/* we're uniprocessor at this point for x86, so store a global pointer to the current thread */
+-struct thread *_current_thread;
+-
+ static void initial_thread_func(void) __NO_RETURN;
+ static void initial_thread_func(void)
+ {
+     int ret;
++    thread_t *cur_thread = get_current_thread();
+ 
+     /* release the thread lock that was implicitly held across the reschedule */
+     spin_unlock(&thread_lock);
+     arch_enable_ints();
+ 
+-    ret = _current_thread->entry(_current_thread->arg);
++    ret = cur_thread->entry(cur_thread->arg);
+ 
+     thread_exit(ret);
+ }
+@@ -123,38 +121,19 @@
+         :
+         : "d" (&oldthread->arch.sp), "a" (newthread->arch.sp)
+     );
+-
+-    /*__asm__ __volatile__ (
+-        "pushf              \n\t"
+-        "pushl %%cs         \n\t"
+-        "pushl $1f          \n\t"
+-        "pushl %%gs         \n\t"
+-        "pushl %%fs         \n\t"
+-        "pushl %%es         \n\t"
+-        "pushl %%ds         \n\t"
+-        "pusha              \n\t"
+-        "movl %%esp,(%%edx) \n\t"
+-        "movl %%eax,%%esp   \n\t"
+-        "popa               \n\t"
+-        "popl %%ds          \n\t"
+-        "popl %%es          \n\t"
+-        "popl %%fs          \n\t"
+-        "popl %%gs          \n\t"
+-        "iret               \n\t"
+-        "1: "
+-        :
+-        : "d" (&oldthread->arch.sp), "a" (newthread->arch.sp)
+-    );*/
+ }
+-#endif
+ 
+-#if ARCH_X86_64
++#elif ARCH_X86_64
+ 
+ void arch_context_switch(thread_t *oldthread, thread_t *newthread)
+ {
++    uint64_t stack_top = (uint64_t)newthread->stack + newthread->stack_size;
++    tss_t *tss_base= get_tss_base();
+ #if X86_WITH_FPU
+     fpu_context_switch(oldthread, newthread);
+ #endif
++    tss_base->rsp0 = stack_top;
++    write_msr(SYSENTER_ESP_MSR, stack_top);
+ 
+     x86_64_context_switch(&oldthread->arch.sp, newthread->arch.sp);
+ }
+diff --git a/arch/x86/toolchain.mk b/arch/x86/toolchain.mk
+index dba751e..aa041fd 100644
+--- a/arch/x86/toolchain.mk
++++ b/arch/x86/toolchain.mk
+@@ -22,13 +22,30 @@
+ 
+ ifndef ARCH_x86_64_TOOLCHAIN_PREFIX
+ ARCH_x86_64_TOOLCHAIN_PREFIX := x86_64-elf-
+-FOUNDTOOL=$(shell which $(ARCH_x86_64_TOOLCHAIN_PREFIX)gcc)
+ endif
+ 
++FOUNDTOOL=$(shell which $(ARCH_x86_64_TOOLCHAIN_PREFIX)gcc)
+ ifeq ($(FOUNDTOOL),)
+ $(error cannot find toolchain, please set ARCH_x86_64_TOOLCHAIN_PREFIX or add it to your path)
+ endif
+ 
++ifeq ($(call TOBOOL,$(CLANGBUILD)),true)
++
++CLANG_X86_64_TARGET_SYS ?= linux
++CLANG_X86_64_TARGET_ABI ?= gnu
++
++CLANG_X86_64_AS_DIR := $(shell dirname $(shell dirname $(ARCH_x86_64_TOOLCHAIN_PREFIX)))
++
++AS_PATH := $(wildcard $(CLANG_X86_64_AS_DIR)/*/bin/as)
++ifeq ($(AS_PATH),)
++$(error Could not find $(CLANG_X86_64_AS_DIR)/*/bin/as, did the directory structure change?)
++endif
++
++ARCH_x86_COMPILEFLAGS += -target x86_64-$(CLANG_X86_64_TARGET_SYS)-$(CLANG_X86_64_TARGET_ABI) \
++                         --gcc-toolchain=$(CLANG_X86_64_AS_DIR)/
++
++endif
++
+ endif
+ endif
+ 
+diff --git a/engine.mk b/engine.mk
+index c0a45fa..527c149 100644
+--- a/engine.mk
++++ b/engine.mk
+@@ -133,6 +133,9 @@
+ # comment out or override if you want to see the full output of each command
+ NOECHO ?= @
+ 
++# try to include the project file
++-include project/$(PROJECT).mk
++
+ # default to building with clang
+ CLANGBUILD ?= true
+ override CLANGBUILD := $(call TOBOOL,$(CLANGBUILD))
+@@ -141,8 +144,6 @@
+ GLOBAL_COMPILEFLAGS += -Wimplicit-fallthrough
+ endif
+ 
+-# try to include the project file
+--include project/$(PROJECT).mk
+ ifndef TARGET
+ $(error couldn't find project or project doesn't define target)
+ endif
+@@ -184,6 +185,10 @@
+ 	LK_DEBUGLEVEL=$(DEBUG)
+ endif
+ 
++ifeq ($(call TOBOOL,$(ENABLE_STATIC_LIB)),true)
++STATIC_LIBS :=
++endif
++
+ # allow additional defines from outside the build system
+ ifneq ($(EXTERNAL_DEFINES),)
+ GLOBAL_DEFINES += $(EXTERNAL_DEFINES)
+diff --git a/include/arch/ops.h b/include/arch/ops.h
+index f097751..906757e 100644
+--- a/include/arch/ops.h
++++ b/include/arch/ops.h
+@@ -40,8 +40,14 @@
+ 
+ static int atomic_swap(volatile int *ptr, int val);
+ static int atomic_add(volatile int *ptr, int val);
++
++#if ARCH_X86_64
++static int atomic_and(volatile int *ptr, long val);
++static int atomic_or(volatile int *ptr, long val);
++#else
+ static int atomic_and(volatile int *ptr, int val);
+ static int atomic_or(volatile int *ptr, int val);
++#endif
+ 
+ static uint32_t arch_cycle_count(void);
+ 
+diff --git a/include/arch/usercopy.h b/include/arch/usercopy.h
+index 028d399..cdc4662 100644
+--- a/include/arch/usercopy.h
++++ b/include/arch/usercopy.h
+@@ -26,8 +26,7 @@
+ 
+ #include <sys/types.h>
+ 
+-//TODO: Add support for 64-bit user_addr_t
+-typedef uint32_t user_addr_t;
++typedef uintptr_t user_addr_t;
+ 
+ status_t arch_copy_from_user(void *kdest, user_addr_t usrc, size_t len);
+ status_t arch_copy_to_user(user_addr_t udest, const void *ksrc, size_t len);
+diff --git a/lib/libc/include/string.h b/lib/libc/include/string.h
+index c6aa757..32b7656 100644
+--- a/lib/libc/include/string.h
++++ b/lib/libc/include/string.h
+@@ -25,6 +25,7 @@
+ 
+ #include <stddef.h>
+ #include <lk/compiler.h>
++#include <sys/types.h>
+ 
+ __BEGIN_CDECLS
+ 
+@@ -33,6 +34,7 @@
+ void *memcpy (void *, void const *, size_t);
+ void *memmove(void *, void const *, size_t);
+ void *memset (void *, int, size_t);
++status_t memcpy_s(void *, size_t, const void *, size_t);
+ 
+ char       *strcat(char *, char const *);
+ char       *strchr(char const *, int) __PURE;
+diff --git a/lib/libc/string/arch/x86-64/memcpy.S b/lib/libc/string/arch/x86-64/memcpy.S
+deleted file mode 100644
+index 84aec44..0000000
+--- a/lib/libc/string/arch/x86-64/memcpy.S
++++ /dev/null
+@@ -1,38 +0,0 @@
+-/*
+- * Copyright (c) 2009 Corey Tabaka
+- *
+- * Permission is hereby granted, free of charge, to any person obtaining
+- * a copy of this software and associated documentation files
+- * (the "Software"), to deal in the Software without restriction,
+- * including without limitation the rights to use, copy, modify, merge,
+- * publish, distribute, sublicense, and/or sell copies of the Software,
+- * and to permit persons to whom the Software is furnished to do so,
+- * subject to the following conditions:
+- *
+- * The above copyright notice and this permission notice shall be
+- * included in all copies or substantial portions of the Software.
+- *
+- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+- * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+- * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+- * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+- * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+- */
+-#include <asm.h>
+-
+-/* TODO: */
+-
+-.text
+-.align 2
+-
+-/* void bcopy(const void *src, void *dest, size_t n); */
+-FUNCTION(bcopy)
+-    ret
+-
+-/* void *memcpy(void *dest, const void *src, size_t n); */
+-FUNCTION(memmove)
+-FUNCTION(memcpy)
+-    ret
+-
+diff --git a/lib/libc/string/arch/x86-64/memset.S b/lib/libc/string/arch/x86-64/memset.S
+deleted file mode 100644
+index 43367f6..0000000
+--- a/lib/libc/string/arch/x86-64/memset.S
++++ /dev/null
+@@ -1,37 +0,0 @@
+-/*
+- * Copyright (c) 2009 Corey Tabaka
+- *
+- * Permission is hereby granted, free of charge, to any person obtaining
+- * a copy of this software and associated documentation files
+- * (the "Software"), to deal in the Software without restriction,
+- * including without limitation the rights to use, copy, modify, merge,
+- * publish, distribute, sublicense, and/or sell copies of the Software,
+- * and to permit persons to whom the Software is furnished to do so,
+- * subject to the following conditions:
+- *
+- * The above copyright notice and this permission notice shall be
+- * included in all copies or substantial portions of the Software.
+- *
+- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+- * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+- * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+- * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+- * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+- */
+-#include <asm.h>
+-
+-/* TODO: */
+-
+-.text
+-.align 2
+-
+-/* void bzero(void *s, size_t n); */
+-FUNCTION(bzero)
+-    ret
+-
+-/* void *memset(void *s, int c, size_t n); */
+-FUNCTION(memset)
+-    ret
+-
+diff --git a/lib/libc/string/arch/x86-64/rules.mk b/lib/libc/string/arch/x86-64/rules.mk
+deleted file mode 100644
+index 3dc080b..0000000
+--- a/lib/libc/string/arch/x86-64/rules.mk
++++ /dev/null
+@@ -1,11 +0,0 @@
+-LOCAL_DIR := $(GET_LOCAL_DIR)
+-
+-ASM_STRING_OPS := #bcopy bzero memcpy memmove memset
+-
+-MODULE_SRCS += \
+-	#$(LOCAL_DIR)/memcpy.S \
+-	#$(LOCAL_DIR)/memset.S
+-
+-# filter out the C implementation
+-C_STRING_OPS := $(filter-out $(ASM_STRING_OPS),$(C_STRING_OPS))
+-
+diff --git a/lib/libc/string/arch/x86/64/memcpy.S b/lib/libc/string/arch/x86/64/memcpy.S
+new file mode 100644
+index 0000000..84aec44
+--- /dev/null
++++ b/lib/libc/string/arch/x86/64/memcpy.S
+@@ -0,0 +1,38 @@
++/*
++ * Copyright (c) 2009 Corey Tabaka
++ *
++ * Permission is hereby granted, free of charge, to any person obtaining
++ * a copy of this software and associated documentation files
++ * (the "Software"), to deal in the Software without restriction,
++ * including without limitation the rights to use, copy, modify, merge,
++ * publish, distribute, sublicense, and/or sell copies of the Software,
++ * and to permit persons to whom the Software is furnished to do so,
++ * subject to the following conditions:
++ *
++ * The above copyright notice and this permission notice shall be
++ * included in all copies or substantial portions of the Software.
++ *
++ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
++ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
++ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
++ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
++ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
++ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
++ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
++ */
++#include <asm.h>
++
++/* TODO: */
++
++.text
++.align 2
++
++/* void bcopy(const void *src, void *dest, size_t n); */
++FUNCTION(bcopy)
++    ret
++
++/* void *memcpy(void *dest, const void *src, size_t n); */
++FUNCTION(memmove)
++FUNCTION(memcpy)
++    ret
++
+diff --git a/lib/libc/string/arch/x86/64/memcpy_s.c b/lib/libc/string/arch/x86/64/memcpy_s.c
+new file mode 100644
+index 0000000..06255fd
+--- /dev/null
++++ b/lib/libc/string/arch/x86/64/memcpy_s.c
+@@ -0,0 +1,41 @@
++/*
++ * Copyright (c) 2018 Intel Corporation
++ *
++ * Permission is hereby granted, free of charge, to any person obtaining
++ * a copy of this software and associated documentation files
++ * (the "Software"), to deal in the Software without restriction,
++ * including without limitation the rights to use, copy, modify, merge,
++ * publish, distribute, sublicense, and/or sell copies of the Software,
++ * and to permit persons to whom the Software is furnished to do so,
++ * subject to the following conditions:
++ *
++ * The above copyright notice and this permission notice shall be
++ * included in all copies or substantial portions of the Software.
++ *
++ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
++ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
++ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
++ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
++ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
++ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
++ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
++ */
++#include <string.h>
++#include <sys/types.h>
++#include <uapi/err.h>
++
++status_t memcpy_s(void *dest, size_t dest_size, const void *src, size_t count)
++{
++    if ((NULL == dest) || (NULL == src))
++        return ERR_NOT_VALID;
++
++    if (0 == count)
++        return NO_ERROR;
++
++    if (dest_size < count)
++        return ERR_OUT_OF_RANGE;
++
++    memcpy(dest, src, count);
++
++    return NO_ERROR;
++}
+diff --git a/lib/libc/string/arch/x86/64/memset.S b/lib/libc/string/arch/x86/64/memset.S
+new file mode 100644
+index 0000000..43367f6
+--- /dev/null
++++ b/lib/libc/string/arch/x86/64/memset.S
+@@ -0,0 +1,37 @@
++/*
++ * Copyright (c) 2009 Corey Tabaka
++ *
++ * Permission is hereby granted, free of charge, to any person obtaining
++ * a copy of this software and associated documentation files
++ * (the "Software"), to deal in the Software without restriction,
++ * including without limitation the rights to use, copy, modify, merge,
++ * publish, distribute, sublicense, and/or sell copies of the Software,
++ * and to permit persons to whom the Software is furnished to do so,
++ * subject to the following conditions:
++ *
++ * The above copyright notice and this permission notice shall be
++ * included in all copies or substantial portions of the Software.
++ *
++ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
++ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
++ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
++ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
++ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
++ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
++ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
++ */
++#include <asm.h>
++
++/* TODO: */
++
++.text
++.align 2
++
++/* void bzero(void *s, size_t n); */
++FUNCTION(bzero)
++    ret
++
++/* void *memset(void *s, int c, size_t n); */
++FUNCTION(memset)
++    ret
++
+diff --git a/lib/libc/string/arch/x86/64/rules.mk b/lib/libc/string/arch/x86/64/rules.mk
+new file mode 100644
+index 0000000..9f76699
+--- /dev/null
++++ b/lib/libc/string/arch/x86/64/rules.mk
+@@ -0,0 +1,10 @@
++LOCAL_DIR := $(GET_LOCAL_DIR)
++
++ASM_STRING_OPS :=
++
++MODULE_SRCS += \
++	$(LOCAL_DIR)/memcpy_s.c
++
++# filter out the C implementation
++C_STRING_OPS := $(filter-out $(ASM_STRING_OPS),$(C_STRING_OPS))
++
+diff --git a/lib/libc/string/arch/x86/memcpy.S b/lib/libc/string/arch/x86/memcpy.S
+deleted file mode 100644
+index 84aec44..0000000
+--- a/lib/libc/string/arch/x86/memcpy.S
++++ /dev/null
+@@ -1,38 +0,0 @@
+-/*
+- * Copyright (c) 2009 Corey Tabaka
+- *
+- * Permission is hereby granted, free of charge, to any person obtaining
+- * a copy of this software and associated documentation files
+- * (the "Software"), to deal in the Software without restriction,
+- * including without limitation the rights to use, copy, modify, merge,
+- * publish, distribute, sublicense, and/or sell copies of the Software,
+- * and to permit persons to whom the Software is furnished to do so,
+- * subject to the following conditions:
+- *
+- * The above copyright notice and this permission notice shall be
+- * included in all copies or substantial portions of the Software.
+- *
+- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+- * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+- * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+- * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+- * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+- */
+-#include <asm.h>
+-
+-/* TODO: */
+-
+-.text
+-.align 2
+-
+-/* void bcopy(const void *src, void *dest, size_t n); */
+-FUNCTION(bcopy)
+-    ret
+-
+-/* void *memcpy(void *dest, const void *src, size_t n); */
+-FUNCTION(memmove)
+-FUNCTION(memcpy)
+-    ret
+-
+diff --git a/lib/libc/string/arch/x86/memset.S b/lib/libc/string/arch/x86/memset.S
+deleted file mode 100644
+index 43367f6..0000000
+--- a/lib/libc/string/arch/x86/memset.S
++++ /dev/null
+@@ -1,37 +0,0 @@
+-/*
+- * Copyright (c) 2009 Corey Tabaka
+- *
+- * Permission is hereby granted, free of charge, to any person obtaining
+- * a copy of this software and associated documentation files
+- * (the "Software"), to deal in the Software without restriction,
+- * including without limitation the rights to use, copy, modify, merge,
+- * publish, distribute, sublicense, and/or sell copies of the Software,
+- * and to permit persons to whom the Software is furnished to do so,
+- * subject to the following conditions:
+- *
+- * The above copyright notice and this permission notice shall be
+- * included in all copies or substantial portions of the Software.
+- *
+- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+- * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+- * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+- * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+- * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+- */
+-#include <asm.h>
+-
+-/* TODO: */
+-
+-.text
+-.align 2
+-
+-/* void bzero(void *s, size_t n); */
+-FUNCTION(bzero)
+-    ret
+-
+-/* void *memset(void *s, int c, size_t n); */
+-FUNCTION(memset)
+-    ret
+-
+diff --git a/lib/libc/string/arch/x86/rules.mk b/lib/libc/string/arch/x86/rules.mk
+index 3dc080b..1babff9 100644
+--- a/lib/libc/string/arch/x86/rules.mk
++++ b/lib/libc/string/arch/x86/rules.mk
+@@ -1,11 +1,5 @@
+ LOCAL_DIR := $(GET_LOCAL_DIR)
+ 
+-ASM_STRING_OPS := #bcopy bzero memcpy memmove memset
+-
+-MODULE_SRCS += \
+-	#$(LOCAL_DIR)/memcpy.S \
+-	#$(LOCAL_DIR)/memset.S
+-
+-# filter out the C implementation
+-C_STRING_OPS := $(filter-out $(ASM_STRING_OPS),$(C_STRING_OPS))
+-
++ifeq ($(SUBARCH),x86-64)
++include $(LOCAL_DIR)/64/rules.mk
++endif
+diff --git a/make/module.mk b/make/module.mk
+index b8aafa9..860cb09 100644
+--- a/make/module.mk
++++ b/make/module.mk
+@@ -92,11 +92,31 @@
+ ifeq (true,$(call TOBOOL,$(MODULE_STATIC_LIB)))
+ 
+ MODULE_OBJECT := $(call TOBUILDDIR,$(MODULE_SRCDIR).mod.a)
++
++ifeq (true,$(call TOBOOL,$(ENABLE_STATIC_LIB)))
++MODULE_NAME := $(notdir $(MODULE_OBJECT))
++FILT_RESULT := $(strip $(foreach t, $(STATIC_LIBS), $(if $(filter $(notdir $(t)), $(MODULE_NAME)), $(t),)))
++
++ifneq ($(FILT_RESULT),)
++MODULE_OBJECT := $(FILT_RESULT)
++$(MODULE_OBJECT) :
++else
++STATIC_LIBS += $(MODULE_OBJECT)
++
+ $(MODULE_OBJECT): $(MODULE_OBJS) $(MODULE_EXTRA_OBJS)
+ 	@$(MKDIR)
+ 	@echo creating $@
+ 	$(NOECHO)rm -f $@
+ 	$(NOECHO)$(AR) rcs $@ $^
++endif
++
++else
++$(MODULE_OBJECT): $(MODULE_OBJS) $(MODULE_EXTRA_OBJS)
++	@$(MKDIR)
++	@echo creating $@
++	$(NOECHO)rm -f $@
++	$(NOECHO)$(AR) rcs $@ $^
++endif
+ 
+ else
+ 

--- a/aosp_diff/linux_trusty/trusty/lib/0001-enable-x86-64-google-diff.patch
+++ b/aosp_diff/linux_trusty/trusty/lib/0001-enable-x86-64-google-diff.patch
@@ -1,0 +1,181 @@
+From 72080db7033bbbbb4c236e6b4645ce4ff713e83e Mon Sep 17 00:00:00 2001
+From: Zhong,Fangjian <fangjian.zhong@intel.com>
+Date: Mon, 23 Apr 2018 08:22:37 +0800
+Subject: [PATCH] enabling x86-64 Google diff
+
+Change-Id: Ib6a7ac3b97b203e11bb58b51b77880131456f7b5
+Tracked-On: https://jira01.devtools.intel.com/browse/OAM-63646
+Signed-off-by: Zhong,Fangjian <fangjian.zhong@intel.com>
+---
+
+diff --git a/include/user/trusty_ipc.h b/include/user/trusty_ipc.h
+index 33a8ccd..860d836 100644
+--- a/include/user/trusty_ipc.h
++++ b/include/user/trusty_ipc.h
+@@ -73,7 +73,7 @@
+ } ipc_msg_t;
+ 
+ typedef struct ipc_msg_info {
+-	size_t		len;
++	uint32_t	len;
+ 	uint32_t	id;
+ 	uint32_t	num_handles;
+ } ipc_msg_info_t;
+diff --git a/include/user/trusty_uuid.h b/include/user/trusty_uuid.h
+index c6cb9a2..61592e8 100644
+--- a/include/user/trusty_uuid.h
++++ b/include/user/trusty_uuid.h
+@@ -24,6 +24,7 @@
+ #pragma once
+ 
+ #include <sys/types.h>
++#include "trusty_apps_uuid.h"
+ 
+ typedef struct uuid
+ {
+diff --git a/lib/hwkey/hwkey.c b/lib/hwkey/hwkey.c
+index 40603f9..14a94c2 100644
+--- a/lib/hwkey/hwkey.c
++++ b/lib/hwkey/hwkey.c
+@@ -109,13 +109,13 @@
+ 
+ 	if (inf.len > sizeof(*msg) + *rsp_buf_len) {
+ 		TLOGE("%s: insufficient output buffer size (%zu > %zu)\n",
+-		      __func__, inf.len - sizeof(*msg), *rsp_buf_len);
++		      __func__, inf.len - sizeof(*msg), (size_t)*rsp_buf_len);
+ 		rc = ERR_TOO_BIG;
+ 		goto err_get_fail;
+ 	}
+ 
+ 	if (inf.len < sizeof(*msg)) {
+-		TLOGE("%s: short buffer (%zu)\n", __func__, inf.len);
++		TLOGE("%s: short buffer (%u)\n", __func__, inf.len);
+ 		rc = ERR_NOT_VALID;
+ 		goto err_get_fail;
+ 	}
+@@ -143,10 +143,10 @@
+ 		goto err_read_fail;
+ 	}
+ 
+-	size_t read_len = (size_t) rc;
++	uint32_t read_len = rc;
+ 	if (read_len != inf.len) {
+ 		// data read in does not match message length
+-		TLOGE("%s: invalid read length (%zu != %zu)\n",
++		TLOGE("%s: invalid read length (%u != %u)\n",
+ 		       __func__, read_len, inf.len);
+ 		rc = ERR_IO;
+ 		goto err_read_fail;
+diff --git a/lib/keymaster/keymaster.c b/lib/keymaster/keymaster.c
+index abb2510..f78e672 100644
+--- a/lib/keymaster/keymaster.c
++++ b/lib/keymaster/keymaster.c
+@@ -139,7 +139,7 @@
+ 	}
+ 
+ 	if (inf.len <= sizeof(struct keymaster_message)) {
+-		TLOGE("%s: invalid auth token len (%zu)\n", __func__, inf.len);
++		TLOGE("%s: invalid auth token len (%u)\n", __func__, inf.len);
+ 		put_msg(session, inf.id);
+ 		return ERR_NOT_FOUND;
+ 	}
+@@ -147,7 +147,7 @@
+ 	size_t size = inf.len - sizeof(struct keymaster_message);
+ 	uint8_t *key_buf = malloc(size);
+ 	if (key_buf == NULL) {
+-		TLOGE("%s: out of memory (%zu)\n", __func__, inf.len);
++		TLOGE("%s: out of memory (%u)\n", __func__, inf.len);
+ 		put_msg(session, inf.id);
+ 		return ERR_NO_MEMORY;
+ 	}
+@@ -158,10 +158,10 @@
+ 		goto err_bad_read;
+ 	}
+ 
+-	size_t read_len = (size_t) rc;
++	uint32_t read_len = rc;
+ 	if (read_len != inf.len){
+ 		// data read in does not match message length
+-		TLOGE("%s: invalid read length: (%zu != %zu)\n",
++		TLOGE("%s: invalid read length: (%u != %u)\n",
+ 		      __func__, read_len, inf.len);
+ 		rc = ERR_IO;
+ 		goto err_bad_read;
+diff --git a/lib/libc-trusty/arch/x86/64/trusty_syscall.S b/lib/libc-trusty/arch/x86/64/trusty_syscall.S
+index 3ffec57..e116521 100644
+--- a/lib/libc-trusty/arch/x86/64/trusty_syscall.S
++++ b/lib/libc-trusty/arch/x86/64/trusty_syscall.S
+@@ -111,11 +111,17 @@
+     pushq %rbp
+     pushq %rbx
+     pushq %r15
++    pushq %rcx
++    movq %rdx, %rcx
++    shr $32, %rcx
++    /* clear high 32 bit of RDX */
++    movl %edx, %edx
+     movq $__NR_nanosleep, %rax
+     leaq .Lnanosleep_sysreturn(%rip), %rbx
+     movq %rsp, %rbp
+     sysenter
+ .Lnanosleep_sysreturn:
++    popq %rcx
+     popq %r15
+     popq %rbx
+     popq %rbp
+diff --git a/lib/libc-trusty/malloc.c b/lib/libc-trusty/malloc.c
+index b3add96..a84a39c 100644
+--- a/lib/libc-trusty/malloc.c
++++ b/lib/libc-trusty/malloc.c
+@@ -53,7 +53,7 @@
+ 	start = (char *)ROUNDUP((long)__libc_brk, SBRK_ALIGN);
+ 	end   = start + ROUNDUP((long)increment, SBRK_ALIGN);
+ 
+-	new_brk = (char *)brk((uint32_t)end);
++	new_brk = (char *)brk((uint32_t)(uint64_t)end);
+ 	if (new_brk < end)
+ 		return (void *)-1;
+ 
+diff --git a/lib/openssl-stubs/sscanf.c b/lib/openssl-stubs/sscanf.c
+index 2cdc4f8..274876f 100644
+--- a/lib/openssl-stubs/sscanf.c
++++ b/lib/openssl-stubs/sscanf.c
+@@ -29,3 +29,8 @@
+ {
+ 	return 0;
+ }
++
++char *getenv(const char *name)
++{
++    return (void *)0;
++}
+diff --git a/lib/rng/rules.mk b/lib/rng/rules.mk
+index bb8139c..dd8c63d 100644
+--- a/lib/rng/rules.mk
++++ b/lib/rng/rules.mk
+@@ -23,6 +23,7 @@
+ 
+ MODULE_DEPS := \
+ 	interface/hwrng \
+-	openssl
++	lib/libc-trusty \
++	lib/boringssl
+ 
+ include make/module.mk
+diff --git a/lib/storage/storage.c b/lib/storage/storage.c
+index 670c9ce..879229d 100644
+--- a/lib/storage/storage.c
++++ b/lib/storage/storage.c
+@@ -144,9 +144,9 @@
+         return rc;
+     }
+ 
+-    if ((size_t)rc != mi.len) {
+-        TLOGE("%s: partial message read (%zd vs. %zd)\n",
+-              __func__, (size_t)rc, mi.len);
++    if ((uint32_t)rc != mi.len) {
++        TLOGE("%s: partial message read (%d vs. %d)\n",
++              __func__, rc, mi.len);
+         return ERR_IO;
+     }
+ 

--- a/aosp_diff/linux_trusty/trusty/lk/trusty/0001-enable-x86-64-google-diff-patch.patch
+++ b/aosp_diff/linux_trusty/trusty/lk/trusty/0001-enable-x86-64-google-diff-patch.patch
@@ -1,0 +1,1196 @@
+From fc4267f7fef07a55cd45e9628069c7a18e77707d Mon Sep 17 00:00:00 2001
+From: Zhong,Fangjian <fangjian.zhong@intel.com>
+Date: Mon, 23 Apr 2018 08:25:42 +0800
+Subject: [PATCH] enabling x86-64 Google diff patch
+
+Change-Id: I9a043fcf25dcf20479d9d98d5d1248fbf8a48d88
+Tracked-On: https://jira01.devtools.intel.com/browse/OAM-63646
+Signed-off-by: Zhong,Fangjian <fangjian.zhong@intel.com>
+---
+
+diff --git a/lib/memlog/memlog.c b/lib/memlog/memlog.c
+index 99e4d91..0db7784 100644
+--- a/lib/memlog/memlog.c
++++ b/lib/memlog/memlog.c
+@@ -38,7 +38,12 @@
+ 
+ #include "trusty-log.h"
+ 
++#ifdef EPT_DEBUG
++#include <platform/vmcall.h>
++#endif
++
+ #define LOG_LOCK_FLAGS SPIN_LOCK_FLAG_IRQ_FIQ
++int having_print_cb = 0;
+ 
+ struct memlog {
+ 	struct log_rb *rb;
+@@ -140,6 +145,11 @@
+ 	if (err) {
+ 		return err;
+ 	}
++
++#ifdef EPT_DEBUG
++	make_ept_update_vmcall(ADD, pa, sz);
++#endif
++
+ 	*va += offset;
+ 	return err;
+ }
+@@ -195,6 +205,8 @@
+ 
+ 	log->cb.print = memlog_print_callback;
+ 	register_print_callback(&log->cb);
++	having_print_cb = 0;
++
+ 	return 0;
+ 
+ error_failed_to_map:
+@@ -214,6 +226,11 @@
+ 	unregister_print_callback(&log->cb);
+ 	list_delete(&log->entry);
+ 	result = vmm_free_region(vmm_get_kernel_aspace(), (vaddr_t)log->rb);
++
++#ifdef EPT_DEBUG
++	make_ept_update_vmcall(REMOVE, pa, log->buf_sz);
++#endif
++
+ 	free(log);
+ 	if (result != NO_ERROR) {
+ 		return SM_ERR_INTERNAL_FAILURE;
+diff --git a/lib/sm/include/lib/sm.h b/lib/sm/include/lib/sm.h
+index 4fca6bf..fcc6ca4 100644
+--- a/lib/sm/include/lib/sm.h
++++ b/lib/sm/include/lib/sm.h
+@@ -27,6 +27,7 @@
+ #include <stddef.h>
+ #include <sys/types.h>
+ #include <lib/sm/smcall.h>
++#include <lk/list.h>
+ 
+ typedef uint64_t ns_addr_t;
+ typedef uint32_t ns_size_t;
+@@ -85,5 +86,34 @@
+ status_t smc32_decode_mem_buf_info(struct smc32_args *args, ns_addr_t *ppa,
+                                    ns_size_t *psz, uint *pmmu);
+ 
++/* sm_wall */
++#if WITH_SM_WALL
++
++struct sm_wall_item {
++	struct list_node node;
++	void (*update_cb)(struct sm_wall_item *wi, void *item);
++	uint32_t item_id;
++	uint32_t size;
++	uint32_t offset;
++};
++
++#define SM_WALL_ITEM_INITIALIZE(id, cb, sz) \
++{                                           \
++	.node = LIST_INITIAL_CLEARED_VALUE,     \
++	.item_id = (id),                        \
++	.update_cb = (cb),                      \
++	.size  = (sz),                          \
++	.offset = 0,                            \
++}
++
++void sm_wall_register_per_cpu_item(struct sm_wall_item *wi);
++void sm_wall_update(void);
++
++/* smc handlers */
++long smc_get_wall_size(smc32_args_t *args);
++long smc_setup_wall_stdcall(smc32_args_t *args);
++long smc_destroy_wall_stdcall(smc32_args_t *args);
++
++#endif /* WITH_SM_WALL */
+ #endif /* __SM_H */
+ 
+diff --git a/lib/sm/include/lib/sm/sm_wall.h b/lib/sm/include/lib/sm/sm_wall.h
+new file mode 100644
+index 0000000..68404e8
+--- /dev/null
++++ b/lib/sm/include/lib/sm/sm_wall.h
+@@ -0,0 +1,98 @@
++/*
++ * Copyright (c) 2016 Google Inc. All rights reserved
++ *
++ * Permission is hereby granted, free of charge, to any person obtaining
++ * a copy of this software and associated documentation files
++ * (the "Software"), to deal in the Software without restriction,
++ * including without limitation the rights to use, copy, modify, merge,
++ * publish, distribute, sublicense, and/or sell copies of the Software,
++ * and to permit persons to whom the Software is furnished to do so,
++ * subject to the following conditions:
++ *
++ * The above copyright notice and this permission notice shall be
++ * included in all copies or substantial portions of the Software.
++ *
++ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
++ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
++ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
++ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
++ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
++ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
++ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
++ */
++#ifndef __LIB_SM_SM_WALL_H
++#define __LIB_SM_SM_WALL_H
++
++/**
++ * DOC: Introduction
++ *
++ * SM Wall buffer is formatted by secure side to contain the location of
++ * objects it exports:
++ *
++ * In general it starts with sm_wall_toc header struct followed
++ * by array of sm_wall_toc_item objects describing location of
++ * individual objects within SM Wall buffer.
++ */
++
++/* current version of TOC structure */
++#define SM_WALL_TOC_VER   1
++
++/**
++ * struct sm_wall_toc_item - describes individual table of content item
++ * @id:           item id
++ * @offset:       item offset relative to appropriate base. For global items
++ * it is relative to SM wall buffer base address. For per cpu item, this is an
++ * offset within each individual per cpu region.
++ * @size:         item size
++ * @reserved:     reserved: must be set to zero
++ */
++struct sm_wall_toc_item {
++	u32 id;
++	u32 offset;
++	u32 size;
++	u32 reserved;
++};
++
++/**
++ * struct sm_wall_toc - describes sm_wall table of content structure
++ * @version:             current toc structure version
++ * @cpu_num:             number of cpus supported
++ * @per_cpu_toc_offset:  offset of the start of per_cpu item table relative to
++ *                       SM wall buffer base address.
++ * @per_cpu_num_items:   number of per cpu toc items located at position
++ *                       specified by @per_cpu_toc_offset.
++ * @per_cpu_base_offset: offset of the start of a sequence of per cpu data
++ *                       regions (@cpu_num total) relative to SM wall buffer
++ *                       base address.
++ * @per_cpu_region_size: size of each per cpu data region.
++ * @global_toc_offset:   offset of the start of global item table relative to
++ *                       SM wall buffer base address.
++ * @global_num_items:    number of items in global item table
++ */
++struct sm_wall_toc {
++	u32 version;
++	u32 cpu_num;
++	u32 per_cpu_toc_offset;
++	u32 per_cpu_num_items;
++	u32 per_cpu_base_offset;
++	u32 per_cpu_region_size;
++	u32 global_toc_offset;
++	u32 global_num_items;
++};
++
++/* ID's of well known wall objects */
++#define SM_WALL_PER_CPU_SEC_TIMER_ID  1
++
++/**
++ * struct sec_timer_state - structure to hold secute timer state
++ * @tv_ns:      If non-zero this field contains snapshot of timers
++ *              current time (ns). Timer is not set otherwise.
++ * @cv_ns:      next timer event configured (ns)
++ */
++struct sec_timer_state {
++	u64 tv_ns;
++	u64 cv_ns;
++};
++
++#endif /* __LIB_SM_SM_WALL_H */
++
+diff --git a/lib/sm/include/lib/sm/smcall.h b/lib/sm/include/lib/sm/smcall.h
+index dc73270..13a2349 100644
+--- a/lib/sm/include/lib/sm/smcall.h
++++ b/lib/sm/include/lib/sm/smcall.h
+@@ -126,6 +126,25 @@
+ 
+ #define SMC_FC_FIQ_RESUME	SMC_FASTCALL_NR (SMC_ENTITY_SECURE_MONITOR, 12)
+ 
++/*
++ * SM Wall is a shared memory buffer established between secure and non-secure
++ * side that allows for secure side to publish certain state that non-secure
++ * side might acts on. One known example is a state of per CPU timer on
++ * platforms that require migration to broadcast timer in deep idle states.
++ *
++ * SMC_FC_GET_WALL_SIZE - retrieves the size of memory buffer that will be
++ * required to setup the SM Wall object.
++ *
++ * SMC_SC_SETUP_WALL - specifies location, size and attributes of memory buffer
++ * allocated by non-secure side to setup the SM Wall object.
++ *
++ * SMC_SC_DESTROY_WALL - notifies secure side that previously specifies SM Wall
++ * object should be released usually as part of normal shutdown sequence.
++ */
++#define SMC_FC_GET_WALL_SIZE	SMC_FASTCALL_NR(SMC_ENTITY_SECURE_MONITOR, 20)
++#define SMC_SC_SETUP_WALL	SMC_STDCALL_NR(SMC_ENTITY_SECURE_MONITOR,  12)
++#define SMC_SC_DESTROY_WALL	SMC_STDCALL_NR(SMC_ENTITY_SECURE_MONITOR,  13)
++
+ /* TRUSTED_OS entity calls */
+ #define SMC_SC_VIRTIO_GET_DESCR	SMC_STDCALL_NR(SMC_ENTITY_TRUSTED_OS, 20)
+ #define SMC_SC_VIRTIO_START	SMC_STDCALL_NR(SMC_ENTITY_TRUSTED_OS, 21)
+diff --git a/lib/sm/rules.mk b/lib/sm/rules.mk
+index 6950f24..12da425 100644
+--- a/lib/sm/rules.mk
++++ b/lib/sm/rules.mk
+@@ -34,6 +34,11 @@
+ 	$(LOCAL_DIR)/smcall.c \
+ 	$(LOCAL_DIR)/ns_mem.c \
+ 
++ifeq (true,$(call TOBOOL,$(WITH_SM_WALL)))
++GLOBAL_DEFINES += WITH_SM_WALL=1
++MODULE_SRCS += \
++	$(LOCAL_DIR)/smwall.c
++endif
+ include $(LOCAL_DIR)/arch/$(ARCH)/rules.mk
+ 
+ include make/module.mk
+diff --git a/lib/sm/sm.c b/lib/sm/sm.c
+index 7b91044..0cda51e 100644
+--- a/lib/sm/sm.c
++++ b/lib/sm/sm.c
+@@ -186,6 +186,9 @@
+ {
+ 	smc32_args_t args = SMC32_ARGS_INITIAL_VALUE(args);
+ 
++#if WITH_SM_WALL
++	sm_wall_update();
++#endif
+ 	do {
+ 		arch_disable_fiqs();
+ 		sm_sched_nonsecure(ret, &args);
+@@ -514,4 +517,4 @@
+ 				"at the end of initialzation!\n");
+ }
+ 
+-LK_INIT_HOOK(libsm_bootargs, sm_release_boot_args, LK_INIT_LEVEL_LAST);
++LK_INIT_HOOK(libsm_bootargs, sm_release_boot_args, LK_INIT_LEVEL_LAST-1);
+diff --git a/lib/sm/smcall.c b/lib/sm/smcall.c
+index e78e704..731b433 100644
+--- a/lib/sm/smcall.c
++++ b/lib/sm/smcall.c
+@@ -96,6 +96,10 @@
+ 	[SMC_FUNCTION(SMC_SC_LOCKED_NOP)] = smc_nop_stdcall,
+ 	[SMC_FUNCTION(SMC_SC_RESTART_FIQ)] = smc_restart_stdcall,
+ 	[SMC_FUNCTION(SMC_SC_NOP)] = smc_undefined, /* reserve slot in table, not called */
++#if WITH_SM_WALL
++	[SMC_FUNCTION(SMC_SC_SETUP_WALL)] = smc_setup_wall_stdcall,
++	[SMC_FUNCTION(SMC_SC_DESTROY_WALL)] = smc_destroy_wall_stdcall,
++#endif
+ };
+ 
+ static long smc_stdcall_secure_monitor(smc32_args_t *args)
+@@ -171,6 +175,9 @@
+ #endif
+ 	[SMC_FUNCTION(SMC_FC_API_VERSION)] = smc_sm_api_version,
+ 	[SMC_FUNCTION(SMC_FC_FIQ_RESUME)] = smc_intc_fiq_resume,
++#if WITH_SM_WALL
++	[SMC_FUNCTION(SMC_FC_GET_WALL_SIZE)] = smc_get_wall_size,
++#endif
+ };
+ 
+ uint32_t sm_nr_fastcall_functions = countof(sm_fastcall_function_table);
+diff --git a/lib/sm/smwall.c b/lib/sm/smwall.c
+new file mode 100644
+index 0000000..8f22ec6
+--- /dev/null
++++ b/lib/sm/smwall.c
+@@ -0,0 +1,330 @@
++/*
++ * Copyright (c) 2016, Google, Inc. All rights reserved
++ *
++ * Permission is hereby granted, free of charge, to any person obtaining
++ * a copy of this software and associated documentation files
++ * (the "Software"), to deal in the Software without restriction,
++ * including without limitation the rights to use, copy, modify, merge,
++ * publish, distribute, sublicense, and/or sell copies of the Software,
++ * and to permit persons to whom the Software is furnished to do so,
++ * subject to the following conditions:
++ *
++ * The above copyright notice and this permission notice shall be
++ * included in all copies or substantial portions of the Software.
++ *
++ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
++ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
++ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
++ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
++ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
++ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
++ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
++ */
++#include <assert.h>
++#include <arch/spinlock.h>
++#include <err.h>
++#include <kernel/mutex.h>
++#include <kernel/vm.h>
++#include <list.h>
++#include <lib/sm.h>
++#include <lib/sm/sm_err.h>
++#include <lib/sm/sm_wall.h>
++#include <lk/init.h>
++#include <malloc.h>
++#include <pow2.h>
++#include <stdlib.h>
++#include <trace.h>
++#include <debug.h>
++
++#ifdef EPT_DEBUG
++#include <platform/vmcall.h>
++#endif
++
++#define LOCAL_TRACE 0
++
++#define ITEM_ALIGNMENT  8
++
++#ifdef EPT_DEBUG
++static paddr_t wall_pa;
++#endif
++
++static vaddr_t wall_va;
++static size_t  wall_sz;
++static bool    wall_registration_closed;
++
++static uint32_t per_cpu_sz;
++static uint32_t per_cpu_offset;
++static uint32_t per_cpu_item_cnt;
++static struct list_node per_cpu_items = LIST_INITIAL_VALUE(per_cpu_items);
++
++static spin_lock_t wall_locks[SMP_MAX_CPUS] = {
++    [0 ... SMP_MAX_CPUS-1] = SPIN_LOCK_INITIAL_VALUE,
++};
++
++static void lock_wall(void)
++{
++    for (int i = 0; i < SMP_MAX_CPUS; i++)
++        spin_lock(&wall_locks[i]);
++}
++
++static void unlock_wall(void)
++{
++    for (int i = SMP_MAX_CPUS-1; i >= 0; i--)
++        spin_unlock(&wall_locks[i]);
++}
++
++/*
++ *  Called by sm module before returning to non-secure world
++ */
++void sm_wall_update(void)
++{
++    struct sm_wall_item *wi;
++    uint cpu = arch_curr_cpu_num();
++
++    //:TODO: Need to fix this bug.
++    //ASSERT(wall_registration_closed);
++    ASSERT(arch_ints_disabled());
++
++    /* update per cpu items */
++    spin_lock(&wall_locks[cpu]);
++    if (wall_va) {
++        list_for_every_entry(&per_cpu_items, wi, struct sm_wall_item, node) {
++            if (wi->update_cb) {
++                vaddr_t item_va = wall_va + per_cpu_offset +
++                                  cpu * per_cpu_sz + wi->offset;
++                wi->update_cb(wi, (void *)item_va);
++            }
++        }
++    }
++    spin_unlock(&wall_locks[cpu]);
++}
++
++/*
++ * called by non-secure side to get required buffer size
++ */
++long smc_get_wall_size(smc32_args_t *args)
++{
++    ASSERT(wall_registration_closed);
++    return wall_sz;
++}
++
++/*
++ * Write The Wall Table of Content to provided buffer
++ */
++static void sm_wall_format(void *va)
++{
++    uint32_t offset = 0;
++    struct sm_wall_item *wi;
++    struct sm_wall_toc_item *item;
++    struct sm_wall_toc *toc = (struct sm_wall_toc *)va;
++
++    toc->version = SM_WALL_TOC_VER;
++    toc->cpu_num = SMP_MAX_CPUS;
++
++    /* per cpu items */
++    toc->per_cpu_region_size = per_cpu_sz;
++    toc->per_cpu_num_items = per_cpu_item_cnt;
++
++    /* global items are not supported yet */
++    toc->global_num_items = 0;
++
++    /* setup per_cpu toc offset and itemst */
++    offset = ALIGN(sizeof(struct sm_wall_toc), ITEM_ALIGNMENT);
++    toc->per_cpu_toc_offset = offset;
++
++    item = va + toc->per_cpu_toc_offset;
++    list_for_every_entry(&per_cpu_items, wi, struct sm_wall_item, node) {
++        item->id = wi->item_id;
++        item->size = wi->size;
++        item->offset = wi->offset;
++        item->reserved  = 0;
++        offset += sizeof(struct sm_wall_toc_item);
++    }
++
++    /* setup global toc offset and items */
++    toc->global_toc_offset = offset;
++
++    /* setup per_cpu data region base offset */
++    offset = ALIGN(offset, ITEM_ALIGNMENT);
++    toc->per_cpu_base_offset = per_cpu_offset = offset;
++
++    /* TODO: implement global items if needed */
++}
++
++/*
++ *  Called by non-secure side to setup shared buffer
++ */
++long smc_setup_wall_stdcall(smc32_args_t *args)
++{
++    status_t rc;
++    void *ns_va;
++    ns_addr_t ns_pa;
++    ns_size_t ns_sz;
++    uint  mmu_flags;
++
++    ASSERT(wall_registration_closed);
++
++    rc = smc32_decode_mem_buf_info(args, &ns_pa, &ns_sz, &mmu_flags);
++    if (rc) {
++        LTRACEF("smc32_decode_mem_buf_info returned %d\n", rc);
++        if (rc == ERR_NOT_SUPPORTED)
++            return SM_ERR_NOT_SUPPORTED;
++        else
++            return SM_ERR_INTERNAL_FAILURE;
++    }
++
++    /* check provided buffer size */
++    if (ns_sz < wall_sz) {
++        LTRACEF("buffer is too small (%zd bytes required)\n", wall_sz);
++        return SM_ERR_INVALID_PARAMETERS;
++    }
++
++    if (ns_pa & (PAGE_SIZE-1)) {
++        LTRACEF("unexpected alignment 0x%llx\n", ns_pa);
++        return SM_ERR_INVALID_PARAMETERS;
++    }
++
++    if (!ns_pa) {
++        LTRACEF("invalid descr addr 0x%llx\n", ns_pa);
++        return SM_ERR_INVALID_PARAMETERS;
++    }
++
++    if (ns_pa != (paddr_t)ns_pa) {
++        LTRACEF("unsuported addr range 0x%llx\n", ns_pa);
++        return SM_ERR_INVALID_PARAMETERS;
++    }
++
++    /* check other attributes */
++    if (mmu_flags & ARCH_MMU_FLAG_PERM_RO) {
++        LTRACEF("read-write accessible buffer is expected\n");
++        return SM_ERR_INVALID_PARAMETERS;
++    }
++
++#if !ARCH_X86_64
++    if ((mmu_flags & ARCH_MMU_FLAG_CACHE_MASK) != ARCH_MMU_FLAG_CACHED) {
++        LTRACEF("cached memory buffer is expected\n");
++        return SM_ERR_INVALID_PARAMETERS;
++    }
++#endif
++
++    /* map non-secure wall buffer */
++    rc = vmm_alloc_physical(vmm_get_kernel_aspace(), "the wall",
++                            ROUNDUP(ns_sz, PAGE_SIZE),
++                            &ns_va, PAGE_SIZE_SHIFT,
++                            (paddr_t)ns_pa, 0, mmu_flags);
++    if (rc) {
++        LTRACEF("vmm alloc failed (%d)\n", rc);
++        return SM_ERR_INTERNAL_FAILURE;
++    }
++
++#ifdef EPT_DEBUG
++    make_ept_update_vmcall(ADD, ns_pa, wall_sz);
++#endif
++
++    LTRACEF("Mapped: pa=%lld sz=%u @ %p\n", ns_pa, ns_sz, ns_va);
++
++    lock_wall();
++    if (wall_va) {
++        LTRACEF("Already initialized\n");
++        unlock_wall();
++        rc = vmm_free_region(vmm_get_kernel_aspace(), (vaddr_t)ns_va);
++        ASSERT(rc == NO_ERROR);
++        return SM_ERR_NOT_ALLOWED;
++    }
++    sm_wall_format(ns_va);
++    wall_va = (vaddr_t)ns_va;
++
++#ifdef EPT_DEBUG
++    wall_pa = (paddr_t)ns_pa;
++#endif
++
++    unlock_wall();
++
++    return 0;
++}
++
++/*
++ *  Called by non-secure side to release shared buffer
++ */
++long smc_destroy_wall_stdcall(smc32_args_t *args)
++{
++    status_t rc;
++    vaddr_t va = 0;
++
++    ASSERT(wall_registration_closed);
++
++    lock_wall();
++    if (wall_va) {
++        /* detach wall pointer */
++        va = wall_va;
++        wall_va = 0;
++    }
++    unlock_wall();
++
++#ifdef EPT_DEBUG
++    make_ept_update_vmcall(REMOVE, wall_pa, wall_sz);
++#endif
++
++
++    if (va) {
++        LTRACEF("Releasing the wall buffer: %p\n", (void*) va);
++        rc = vmm_free_region(vmm_get_kernel_aspace(), va);
++        ASSERT(rc == NO_ERROR);
++    } else {
++        LTRACEF("Sm_wall is not initialized\n");
++        rc = SM_ERR_NOT_ALLOWED;
++    }
++    return rc;
++}
++
++
++/*
++ * Called during trusty initialization to allocate speace in shared buffer.
++ * All calls to this routine has to be complete before LK_INIT_LEVEL_APPS-2
++ * init level.
++ */
++void sm_wall_register_per_cpu_item(struct sm_wall_item *wi)
++{
++    struct sm_wall_item *tmp;
++
++    ASSERT(wi);
++    ASSERT(!list_in_list(&wi->node));
++    ASSERT(!wall_registration_closed);
++
++    /* check for item_id duplicates and add to the list */
++    lock_wall();
++    list_for_every_entry(&per_cpu_items, tmp, struct sm_wall_item, node) {
++        ASSERT(tmp->item_id == wi->item_id);
++    }
++    list_add_tail(&per_cpu_items, &wi->node);
++    wi->offset = per_cpu_sz;
++    per_cpu_sz = ALIGN(wi->offset + wi->size, ITEM_ALIGNMENT);
++    per_cpu_item_cnt++;
++    unlock_wall();
++}
++
++/*
++ * Invoked at boot to close wall registration
++ */
++static void sm_wall_finish_init(uint lvl)
++{
++    ASSERT(!wall_registration_closed);
++
++    /* close registration */
++    wall_registration_closed = true;
++
++    /* calculate total requred wall buffer size */
++    wall_sz = sizeof(struct sm_wall_toc) +
++              sizeof(struct sm_wall_toc_item) * per_cpu_item_cnt;
++    wall_sz = ALIGN(wall_sz, ITEM_ALIGNMENT);
++    wall_sz += SMP_MAX_CPUS * per_cpu_sz;
++    wall_sz = ALIGN(wall_sz, PAGE_SIZE);
++}
++
++/*
++ * BSP has to launch applications first to make sure APs have
++ * finished register sm wall items.
++ */
++LK_INIT_HOOK_FLAGS(sm_wall_finish_init, sm_wall_finish_init,
++        LK_INIT_LEVEL_APPS + 2, LK_INIT_FLAG_PRIMARY_CPU);
++
+diff --git a/lib/trusty/include/lib/trusty/uio.h b/lib/trusty/include/lib/trusty/uio.h
+index a32af08..542f362 100644
+--- a/lib/trusty/include/lib/trusty/uio.h
++++ b/lib/trusty/include/lib/trusty/uio.h
+@@ -29,7 +29,7 @@
+ 
+ typedef struct iovec_kern {
+ 	void		*base;
+-	size_t		len;
++	uint32_t	len;
+ } iovec_kern_t;
+ 
+ typedef struct iovec_user {
+diff --git a/lib/trusty/include/lib/trusty/uuid.h b/lib/trusty/include/lib/trusty/uuid.h
+index 3baf36b..e91896d 100644
+--- a/lib/trusty/include/lib/trusty/uuid.h
++++ b/lib/trusty/include/lib/trusty/uuid.h
+@@ -23,6 +23,7 @@
+ #pragma once
+ 
+ #include <sys/types.h>
++#include "trusty_apps_uuid.h"
+ 
+ typedef struct uuid
+ {
+diff --git a/lib/trusty/include/syscall_table.h b/lib/trusty/include/syscall_table.h
+index 9cb1d40..cefdfb2 100644
+--- a/lib/trusty/include/syscall_table.h
++++ b/lib/trusty/include/syscall_table.h
+@@ -56,3 +56,6 @@
+ DEF_SYSCALL(0x21, read_msg, long, 4, uint32_t handle, uint32_t msg_id, uint32_t offset, ipc_msg_t *msg)
+ DEF_SYSCALL(0x22, put_msg, long, 2, uint32_t handle, uint32_t msg_id)
+ DEF_SYSCALL(0x23, send_msg, long, 2, uint32_t handle, ipc_msg_t *msg)
++#if WITH_CUSTOMIZED_SYSCALL
++#include "customized_syscall_table.h"
++#endif
+diff --git a/lib/trusty/syscall.c b/lib/trusty/syscall.c
+index 72f575c..a362bbb 100644
+--- a/lib/trusty/syscall.c
++++ b/lib/trusty/syscall.c
+@@ -38,6 +38,7 @@
+ #include <lib/trusty/trusty_app.h>
+ 
+ #define LOCAL_TRACE 0
++#define STD_WRITE_BUF_SIZE 128
+ 
+ static int32_t sys_std_write(uint32_t fd, user_addr_t user_ptr, uint32_t size);
+ 
+@@ -97,17 +98,28 @@
+ /* handle stdout/stderr */
+ static int32_t sys_std_write(uint32_t fd, user_addr_t user_ptr, uint32_t size)
+ {
+-	size_t ret;
++	int32_t ret = 0;
+ 
+ 	/* check buffer is in task's address space */
+-	if (!valid_address((vaddr_t)user_ptr, size))
++	if ((int32_t)size <= 0 || !valid_address((vaddr_t)user_ptr, size))
+ 		return ERR_INVALID_ARGS;
+ 
+ 	if (((fd == 2) ? INFO : SPEW) > LK_DEBUGLEVEL) {
+ 		ret = size;
+ 	} else {
+-		ret = fwrite((const void *)(uintptr_t)user_ptr, 1, size,
+-		             (fd == 2) ? stderr : stdout);
++		char str[STD_WRITE_BUF_SIZE];
++		uint32_t cnt;
++		status_t rc;
++
++		do {
++			cnt = MIN(size, STD_WRITE_BUF_SIZE);
++			rc = copy_from_user(str, user_ptr, cnt);
++			if (rc != NO_ERROR)
++				return rc;
++
++			ret += fwrite(str, 1, cnt, (fd == 2) ? stderr : stdout);
++			size -= cnt;
++		} while (size > 0);
+ 	}
+ 
+ 	return ret;
+@@ -222,8 +234,8 @@
+ 	long ret;
+ 	vaddr_t vaddr = uaddr;
+ 
+-	LTRACEF("uaddr 0x%x, size 0x%x, flags 0x%x, pmem 0x%x\n",
+-	        uaddr, size, flags, pmem);
++	LTRACEF("uaddr 0x%lx, size 0x%x, flags 0x%x, pmem 0x%lx\n",
++	       uaddr, size, flags, pmem);
+ 
+ 	if (size == 0 || !valid_address(vaddr, size))
+ 		return ERR_INVALID_ARGS;
+@@ -260,7 +272,7 @@
+ 
+ long sys_finish_dma(user_addr_t uaddr, uint32_t size, uint32_t flags)
+ {
+-	LTRACEF("uaddr 0x%x, size 0x%x, flags 0x%x\n", uaddr, size, flags);
++	LTRACEF("uaddr 0x%lx, size 0x%x, flags 0x%x\n", uaddr, size, flags);
+ 
+ 	/* check buffer is in task's address space */
+ 	if (!valid_address((vaddr_t)uaddr, size))
+diff --git a/lib/trusty/tipc_dev.c b/lib/trusty/tipc_dev.c
+index 2e60a0c..7060b38 100644
+--- a/lib/trusty/tipc_dev.c
++++ b/lib/trusty/tipc_dev.c
+@@ -103,9 +103,9 @@
+ struct tipc_hdr {
+ 	uint32_t src;
+ 	uint32_t dst;
+-	uint32_t reserved;
+-	uint16_t len;
++	uint32_t len;
+ 	uint16_t flags;
++	uint16_t reserved;
+ 	uint8_t data[0];
+ } __PACKED;
+ 
+@@ -496,7 +496,7 @@
+ 
+ 	/* check message size */
+ 	if (buf->in_iovs.iovs[0].len < sizeof(struct tipc_hdr)) {
+-		LTRACEF("msg too short %zu\n", buf->in_iovs.iovs[0].len);
++		LTRACEF("msg too short %u\n", buf->in_iovs.iovs[0].len);
+ 		ret = ERR_INVALID_ARGS;
+ 		goto done;
+ 	}
+@@ -508,7 +508,7 @@
+ 	dst_addr = ns_hdr->dst;
+ 
+ 	if (ns_data_len + sizeof(struct tipc_hdr) != buf->in_iovs.iovs[0].len) {
+-		LTRACEF("malformed message len %zu msglen %zu\n",
++		LTRACEF("malformed message len %zu msglen %u\n",
+ 			ns_data_len, buf->in_iovs.iovs[0].len);
+ 		ret = ERR_INVALID_ARGS;
+ 		goto done;
+@@ -1069,7 +1069,7 @@
+ 	/* the first iovec should be large enough to hold header */
+ 	if (sizeof(struct tipc_hdr) > buf.out_iovs.iovs[0].len) {
+ 		/* not enough space to even place header */
+-		LTRACEF("buf is too small (%zu < %zu)\n",
++		LTRACEF("buf is too small (%u < %zu)\n",
+ 		         buf.out_iovs.iovs[0].len, ttl_len);
+ 		ret = ERR_NOT_ENOUGH_BUFFER;
+ 		goto done;
+@@ -1091,7 +1091,7 @@
+ 		if (ttl_len > buf.out_iovs.iovs[0].len) {
+ 			/* not enough space to put the whole message
+ 			   so it will be truncated */
+-			LTRACEF("buf is too small (%zu < %zu)\n",
++			LTRACEF("buf is too small (%u < %zu)\n",
+ 			         buf.out_iovs.iovs[0].len, ttl_len);
+ 			data_len = buf.out_iovs.iovs[0].len -
+ 			           sizeof(struct tipc_hdr);
+diff --git a/lib/trusty/tipc_dev_ql.c b/lib/trusty/tipc_dev_ql.c
+index dd63c17..d4fa6e1 100644
+--- a/lib/trusty/tipc_dev_ql.c
++++ b/lib/trusty/tipc_dev_ql.c
+@@ -38,6 +38,9 @@
+ 
+ #include "tipc_dev_ql.h"
+ 
++#ifdef EPT_DEBUG
++#include <platform/vmcall.h>
++#endif
+ #define LOCAL_TRACE 0
+ 
+ /*
+@@ -527,6 +530,7 @@
+ long ql_tipc_handle_cmd(ns_addr_t buf_pa, ns_size_t cmd_sz)
+ {
+ 	struct tipc_cmd_hdr cmd_hdr;
++	status_t ret;
+ 
+ 	/* lookup device */
+ 	struct ql_tipc_dev *dev = dev_lookup(buf_pa);
+@@ -541,15 +545,30 @@
+ 		return SM_ERR_INVALID_PARAMETERS;
+ 	}
+ 
++#ifdef EPT_DEBUG
++	make_ept_update_vmcall(ADD, dev->ns_pa, sizeof(cmd_hdr));
++#endif
++
+ 	/* copy out command header */
+ 	memcpy(&cmd_hdr, dev->ns_va, sizeof(cmd_hdr));
+ 
+ 	/* check for consistency */
+ 	if (cmd_hdr.payload_len != (cmd_sz - sizeof(cmd_hdr))) {
+ 		LTRACEF("malformed command\n");
++
++#ifdef EPT_DEBUG
++	make_ept_update_vmcall(REMOVE, dev->ns_pa, sizeof(cmd_hdr));
++#endif
++
+ 		return SM_ERR_INVALID_PARAMETERS;
+ 	}
+ 
+-	return dev_handle_cmd(dev, &cmd_hdr, dev->ns_va + sizeof(cmd_hdr));
++#ifdef EPT_DEBUG
++	make_ept_update_vmcall(REMOVE, dev->ns_pa, sizeof(cmd_hdr));
++#endif
++
++	ret = dev_handle_cmd(dev, &cmd_hdr, dev->ns_va + sizeof(cmd_hdr));
++
++	return ret;
+ }
+ 
+diff --git a/lib/trusty/trusty_app.c b/lib/trusty/trusty_app.c
+index 7073f2c..ef2f6c4 100644
+--- a/lib/trusty/trusty_app.c
++++ b/lib/trusty/trusty_app.c
+@@ -84,6 +84,18 @@
+ 
+ #define PAGE_MASK               (PAGE_SIZE - 1)
+ 
++#if ARCH_X86_64
++#define Elf_Shdr Elf64_Shdr
++#define Elf_Ehdr Elf64_Ehdr
++#define Elf_Phdr Elf64_Phdr
++#else
++#define Elf_Shdr Elf32_Shdr
++#define Elf_Ehdr Elf32_Ehdr
++#define Elf_Phdr Elf32_Phdr
++#endif
++
++
++
+ static u_int trusty_next_app_id;
+ static struct list_node trusty_app_list = LIST_INITIAL_VALUE(trusty_app_list);
+ 
+@@ -158,7 +170,7 @@
+                                        (const void *)appimg->img_end);
+ }
+ 
+-static bool compare_section_name(Elf32_Shdr *shdr, const char *name,
++static bool compare_section_name(Elf_Shdr *shdr, const char *name,
+                                  char *shstbl, uint32_t shstbl_size)
+ {
+   return shstbl_size - shdr->sh_name > strlen(name) &&
+@@ -279,7 +291,7 @@
+ }
+ 
+ static status_t load_app_config_options(trusty_app_t *trusty_app,
+-                                        Elf32_Shdr *shdr)
++                                        Elf_Shdr *shdr)
+ {
+     char *manifest_data;
+     const char *port_name;
+@@ -292,7 +304,7 @@
+     /* have to at least have a valid UUID */
+     if (shdr->sh_size < sizeof(uuid_t)) {
+         dprintf(CRITICAL, "app %u manifest too small %u\n", trusty_app->app_id,
+-                shdr->sh_size);
++                (uint)shdr->sh_size);
+         return ERR_NOT_VALID;
+     }
+ 
+@@ -431,11 +443,12 @@
+ static status_t init_brk(trusty_app_t *trusty_app, vaddr_t hint)
+ {
+     status_t status;
+-    uint arch_mmu_flags;
++    uint arch_mmu_flags = 0;
+     vaddr_t start_brk;
+     vaddr_t hint_page_end;
+     size_t remaining;
+ 
++#if 0
+     status = arch_mmu_query(&trusty_app->aspace->arch_aspace, hint, NULL,
+                             &arch_mmu_flags);
+     if(status != NO_ERROR) {
+@@ -443,6 +456,7 @@
+                 trusty_app->app_id, status);
+         return ERR_NOT_VALID;
+     }
++#endif
+ 
+     hint_page_end = ROUNDUP(hint, PAGE_SIZE);
+ 
+@@ -481,9 +495,9 @@
+ 
+ static status_t alloc_address_map(trusty_app_t *trusty_app)
+ {
+-    Elf32_Ehdr *elf_hdr = (Elf32_Ehdr *)trusty_app->app_img->img_start;
++    Elf_Ehdr *elf_hdr = (Elf_Ehdr *)trusty_app->app_img->img_start;
+     void *trusty_app_image;
+-    Elf32_Phdr *prg_hdr;
++    Elf_Phdr *prg_hdr;
+     u_int i;
+     status_t ret;
+     vaddr_t start_code = ~0;
+@@ -493,10 +507,10 @@
+     vaddr_t last_mem = 0;
+     trusty_app_image = (void *)trusty_app->app_img->img_start;
+ 
+-    prg_hdr = (Elf32_Phdr *)(trusty_app_image + elf_hdr->e_phoff);
++    prg_hdr = (Elf_Phdr *)(trusty_app_image + elf_hdr->e_phoff);
+ 
+     if (!address_range_within_img(prg_hdr,
+-                                  sizeof(Elf32_Phdr) * elf_hdr->e_phnum,
++                                  sizeof(Elf_Phdr) * elf_hdr->e_phnum,
+                                   trusty_app->app_img)) {
+         dprintf(CRITICAL, "ELF program headers table out of bounds\n");
+         return ERR_NOT_VALID;
+@@ -509,8 +523,8 @@
+ 
+         LTRACEF("trusty_app %d: ELF type 0x%x, vaddr 0x%08x, paddr 0x%08x"
+                 " rsize 0x%08x, msize 0x%08x, flags 0x%08x\n",
+-                trusty_app->app_id, prg_hdr->p_type, prg_hdr->p_vaddr,
+-                prg_hdr->p_paddr, prg_hdr->p_filesz, prg_hdr->p_memsz,
++                trusty_app->app_id, prg_hdr->p_type, (uint)prg_hdr->p_vaddr,
++                (uint)prg_hdr->p_paddr, (uint)prg_hdr->p_filesz, (uint)prg_hdr->p_memsz,
+                 prg_hdr->p_flags);
+ 
+         if (prg_hdr->p_type != PT_LOAD)
+@@ -629,10 +643,10 @@
+                 " rsize 0x%08zx, msize 0x%08x, access r%c%c,"
+                 " flags 0x%x\n",
+                 trusty_app->app_id, vaddr, vaddr_to_paddr((void *)vaddr),
+-                mapping_size, prg_hdr->p_memsz,
++                mapping_size, (uint)prg_hdr->p_memsz,
+                 arch_mmu_flags & ARCH_MMU_FLAG_PERM_RO ? '-' : 'w',
+                 arch_mmu_flags & ARCH_MMU_FLAG_PERM_NO_EXECUTE ? '-' : 'x',
+-                arch_mmu_flags);
++                (uint)arch_mmu_flags);
+ 
+         /* start of code/data */
+         first = prg_hdr->p_vaddr;
+@@ -649,7 +663,7 @@
+             end_data = last;
+ 
+         /* hint for start of brk */
+-        last_mem = MAX(last_mem, prg_hdr->p_vaddr + prg_hdr->p_memsz);
++        last_mem = MAX(last_mem, prg_hdr->p_vaddr + mapping_size);
+     }
+ 
+     ret = init_brk(trusty_app, last_mem);
+@@ -667,7 +681,7 @@
+     dprintf(SPEW, "trusty_app %d: brk:  start 0x%08lx end 0x%08lx\n",
+             trusty_app->app_id, trusty_app->start_brk, trusty_app->end_brk);
+     dprintf(SPEW, "trusty_app %d: entry 0x%08x\n", trusty_app->app_id,
+-            elf_hdr->e_entry);
++            (uint)elf_hdr->e_entry);
+ 
+     return NO_ERROR;
+ }
+@@ -678,9 +692,9 @@
+  */
+ static status_t trusty_app_create(struct trusty_app_img *app_img)
+ {
+-    Elf32_Ehdr *ehdr;
+-    Elf32_Shdr *shdr;
+-    Elf32_Shdr *bss_shdr, *manifest_shdr;
++    Elf_Ehdr *ehdr;
++    Elf_Shdr *shdr;
++    Elf_Shdr *bss_shdr, *manifest_shdr;
+     char *shstbl;
+     uint32_t shstbl_size;
+     trusty_app_t *trusty_app;
+@@ -704,8 +718,8 @@
+         return ERR_NO_MEMORY;
+     }
+ 
+-    ehdr = (Elf32_Ehdr *)app_img->img_start;
+-    if (!address_range_within_img(ehdr, sizeof(Elf32_Ehdr), app_img)) {
++    ehdr = (Elf_Ehdr *)app_img->img_start;
++    if (!address_range_within_img(ehdr, sizeof(Elf_Ehdr), app_img)) {
+         dprintf(CRITICAL, "trusty_app_create: ELF header out of bounds\n");
+         ret = ERR_NOT_VALID;
+         goto err_hdr;
+@@ -717,8 +731,8 @@
+         goto err_hdr;
+     }
+ 
+-    shdr = (Elf32_Shdr *) ((intptr_t)ehdr + ehdr->e_shoff);
+-    if (!address_range_within_img(shdr, sizeof(Elf32_Shdr) * ehdr->e_shnum,
++    shdr = (Elf_Shdr *) ((intptr_t)ehdr + ehdr->e_shoff);
++    if (!address_range_within_img(shdr, sizeof(Elf_Shdr) * ehdr->e_shnum,
+                                   app_img)) {
+         dprintf(CRITICAL, "trusty_app_create: ELF section headers out of bounds\n");
+         ret = ERR_NOT_VALID;
+@@ -747,7 +761,7 @@
+             continue;
+ 
+         LTRACEF("trusty_app: sect %d, off 0x%08x, size 0x%08x, flags 0x%02x, name %s\n",
+-                i, shdr[i].sh_offset, shdr[i].sh_size, shdr[i].sh_flags,
++                i, (uint)shdr[i].sh_offset, (uint)shdr[i].sh_size, (uint)shdr[i].sh_flags,
+                 shstbl + shdr[i].sh_name);
+ 
+         /* track bss and manifest sections */
+@@ -854,7 +868,7 @@
+     char name[32];
+     struct trusty_thread *trusty_thread;
+     struct trusty_app_notifier *n;
+-    Elf32_Ehdr *elf_hdr;
++    Elf_Ehdr *elf_hdr;
+     int ret;
+ 
+     DEBUG_ASSERT(trusty_app->state == APP_STARTING);
+@@ -902,7 +916,7 @@
+         }
+     }
+ 
+-    elf_hdr = (Elf32_Ehdr *)trusty_app->app_img->img_start;
++    elf_hdr = (Elf_Ehdr *)trusty_app->app_img->img_start;
+     trusty_thread = trusty_thread_create(name, elf_hdr->e_entry,
+                                          DEFAULT_PRIORITY,
+                                          TRUSTY_APP_STACK_TOP,
+diff --git a/lib/trusty/trusty_virtio.c b/lib/trusty/trusty_virtio.c
+index f9a6694..4d8f447 100644
+--- a/lib/trusty/trusty_virtio.c
++++ b/lib/trusty/trusty_virtio.c
+@@ -37,6 +37,10 @@
+ #include <remoteproc/remoteproc.h>
+ #include "trusty_virtio.h"
+ 
++#ifdef EPT_DEBUG
++#include <platform/vmcall.h>
++#endif
++
+ #define LOCAL_TRACE  0
+ 
+ /*
+@@ -74,6 +78,8 @@
+ static status_t map_descr(ns_paddr_t buf_pa, void **buf_va, ns_size_t sz,
+                           uint buf_mmu_flags)
+ {
++	status_t err;
++
+ 	if (!buf_pa) {
+ 		LTRACEF("invalid descr addr 0x%llx\n", buf_pa);
+ 		return ERR_INVALID_ARGS;
+@@ -92,14 +98,25 @@
+ #endif
+ 
+ 	/* map resource table into our address space */
+-	return  vmm_alloc_physical(vmm_get_kernel_aspace(), "virtio",
++	err = vmm_alloc_physical(vmm_get_kernel_aspace(), "virtio",
+ 	                           ROUNDUP(sz, PAGE_SIZE),
+ 	                           buf_va, PAGE_SIZE_SHIFT,
+ 	                           (paddr_t) buf_pa, 0, buf_mmu_flags);
++
++#ifdef EPT_DEBUG
++	if (NO_ERROR == err)
++		make_ept_update_vmcall(ADD, buf_pa, sz);
++#endif
++
++	return err;
+ }
+ 
+ static status_t unmap_descr(ns_paddr_t pa, void *va, size_t sz)
+ {
++#ifdef EPT_DEBUG
++	make_ept_update_vmcall(REMOVE, pa, sz);
++#endif
++
+ 	return vmm_free_region(vmm_get_kernel_aspace(), (vaddr_t)va);
+ }
+ 
+diff --git a/lib/trusty/vqueue.c b/lib/trusty/vqueue.c
+index daa3cbd..d3248d8 100644
+--- a/lib/trusty/vqueue.c
++++ b/lib/trusty/vqueue.c
+@@ -37,6 +37,10 @@
+ #include <virtio/virtio_ring.h>
+ #include "vqueue.h"
+ 
++#ifdef EPT_DEBUG
++#include <platform/vmcall.h>
++#endif
++
+ #define LOCAL_TRACE 0
+ 
+ #define VQ_LOCK_FLAGS SPIN_LOCK_FLAG_INTERRUPTS
+@@ -62,6 +66,10 @@
+ 		return (int) ret;
+ 	}
+ 
++#ifdef EPT_DEBUG
++	make_ept_update_vmcall(ADD, paddr, vq->vring_sz);
++#endif
++
+ 	vring_init(&vq->vring, num, vptr, align);
+ 
+ 	vq->id = id;
+@@ -80,6 +88,12 @@
+ 	vaddr_t vring_addr;
+ 	spin_lock_saved_state_t state;
+ 
++#ifdef EPT_DEBUG
++	uint64_t pa, size;
++	pa = vaddr_to_paddr((void *)vq->vring_addr);
++	size = vq->vring_sz;
++#endif
++
+ 	DEBUG_ASSERT(vq);
+ 
+ 	spin_lock_save(&vq->slock, &state, VQ_LOCK_FLAGS);
+@@ -89,6 +103,10 @@
+ 	spin_unlock_restore(&vq->slock, state, VQ_LOCK_FLAGS);
+ 
+ 	vmm_free_region(vmm_get_kernel_aspace(), vring_addr);
++
++#ifdef EPT_DEBUG
++	make_ept_update_vmcall(REMOVE, pa, size);
++#endif
+ }
+ 
+ void vqueue_signal_avail(struct vqueue *vq)
+@@ -226,6 +244,10 @@
+ 		                         vqiovs->phys[i], 0, flags);
+ 		if (ret)
+ 			goto err;
++
++#ifdef EPT_DEBUG
++		make_ept_update_vmcall(ADD, vqiovs->phys[i], vqiovs->iovs[i].len);
++#endif
+ 	}
+ 
+ 	return NO_ERROR;
+@@ -234,6 +256,9 @@
+ 	while (i--) {
+ 		vmm_free_region(vmm_get_kernel_aspace(),
+ 		                (vaddr_t)vqiovs->iovs[i].base);
++#ifdef EPT_DEBUG
++		make_ept_update_vmcall(REMOVE, vqiovs->phys[i], vqiovs->iovs[i].len);
++#endif
+ 		vqiovs->iovs[i].base = NULL;
+ 	}
+ 	return ret;
+@@ -251,6 +276,9 @@
+ 		DEBUG_ASSERT(vqiovs->iovs[i].base);
+ 		vmm_free_region(vmm_get_kernel_aspace(),
+ 		                (vaddr_t)vqiovs->iovs[i].base);
++#ifdef EPT_DEBUG
++		make_ept_update_vmcall(REMOVE, vqiovs->phys[i], vqiovs->iovs[i].len);
++#endif
+ 		vqiovs->iovs[i].base = NULL;
+ 	}
+ }
+diff --git a/make/xbin.mk b/make/xbin.mk
+index 6a7e5a1..4ef2023 100644
+--- a/make/xbin.mk
++++ b/make/xbin.mk
+@@ -89,7 +89,13 @@
+ # Override tools
+ include arch/$(ARCH)/toolchain.mk
+ 
++ifneq ($(ARCH), x86)
+ XBIN_TOOLCHAIN_PREFIX := $(ARCH_$(ARCH)_TOOLCHAIN_PREFIX)
++else
++XBIN_TOOLCHAIN_PREFIX := $(TOOLCHAIN_PREFIX)
++GLOBAL_COMPILEFLAGS := $(filter-out -msoft-float,$(GLOBAL_COMPILEFLAGS))
++GLOBAL_COMPILEFLAGS += -mstack-alignment=4
++endif
+ 
+ ifeq ($(call TOBOOL,$(CLANGBUILD)), true)
+ XBIN_CC := $(CCACHE) $(CLANG_BINDIR)/clang

--- a/linux_trusty.mk
+++ b/linux_trusty.mk
@@ -1,0 +1,53 @@
+################################################################################
+# Copyright (c) 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+TOP_DIR = $(shell pwd)
+
+TOOLCHAIN_ROOT ?= $(TOP_DIR)/toolchain
+
+LK_ENV_VAR += ARCH_x86_64_TOOLCHAIN_INCLUDED=1
+LK_ENV_VAR += BUILDROOT=$(TOP_DIR)/out/trusty/
+LK_ENV_VAR += CLANG_BINDIR=$(TOOLCHAIN_ROOT)/clang/host/linux-x86/clang-4691093/bin
+LK_ENV_VAR += ARCH_x86_64_TOOLCHAIN_PREFIX=$(TOOLCHAIN_ROOT)/gcc/x86_64-linux-android-4.9/bin/x86_64-linux-android-
+
+TRUSTY_CA_ENV_VAR += BUILD_DIR=$(TOP_DIR)/out/trusty_ca/
+
+export TRUSTY_REF_TARGET=linux_trusty
+
+.PHONY: all trusty trusty_ca clean
+
+all: trusty trusty_ca
+
+trusty:
+	@echo '****************************************************************'
+	@echo '*   apply aosp diff patches...'
+	@echo '****************************************************************'
+	@build/aosp_diff/applypatch.sh $(TRUSTY_REF_TARGET)
+
+	@echo '****************************************************************'
+	@echo '*   build trusty os...'
+	@echo '****************************************************************'
+	$(LK_ENV_VAR) $(MAKE) -C trusty sand-x86-64
+
+trusty_ca:
+	@echo '****************************************************************'
+	@echo '*   build trusty client application...'
+	@echo '****************************************************************'
+	$(TRUSTY_CA_ENV_VAR) $(MAKE) -C system/core
+
+clean:
+	$(TRUSTY_ENV_VAR) $(MAKE) -C trusty spotless
+	$(TRUSTY_CA_ENV_VAR)  $(MAKE) -C system/core clean


### PR DESCRIPTION
1, Create linux_trusty.mk and add linux_trusty as new ref target in it.
2, Create new patch folder for linux trusty.

Signed-off-by: Jingdong Lu <jingdong.lu@intel.com>